### PR TITLE
Fixing slashing problem with windows paths

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -36,7 +36,9 @@ resolver.lookup = function (cb) {
 
   this.lookups.forEach(function (lookup) {
     generatorsModules.forEach(function (modulePath) {
-      patterns.push(path.join(modulePath, lookup) + '/*/index.js');
+      var pattern = path.join(modulePath, lookup) + '/*/index.js';
+      if (patterns.indexOf(pattern) == -1)
+        patterns.push(win32 ? pattern.replace(/\\/g, "/") : pattern);
     });
   });
 


### PR DESCRIPTION
I am using windows 7 and my Yeoman suddenly can't find generators (@@). Turns out it seems to be a slashing problem in windows, when path to node module is like ....\AppData\Roaming\npm\node_modules\

It should be changed to forward slash (/) for the sync function work properly, I think.