### PR TITLE
Support for scoped generators (fixes #14)

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -377,6 +377,11 @@ Environment.prototype.namespace = function namespace(filepath) {
     return ns.replace(lookup, '');
   }, ns);
 
+  var folders = ns.split(path.sep);
+  var scope = _.findLast(folders, function (folder) {
+    return folder.indexOf('@') === 0;
+  });
+
   // cleanup `ns` from unwanted parts and then normalize slashes to `:`
   ns = ns
     .replace(/(.*generator-)/, '') // remove before `generator-`
@@ -386,6 +391,10 @@ Environment.prototype.namespace = function namespace(filepath) {
     .replace(/[\/\\]+/g, ':'); // replace slashes by `:`
 
   debug('Resolve namespaces for %s: %s', filepath, ns);
+
+  if (scope){
+    ns = scope + '/' + ns;
+  }
 
   return ns;
 };

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -378,7 +378,7 @@ Environment.prototype.namespace = function namespace(filepath) {
     .replace(/^[\/\\]+/, '') // remove leading `/`
     .replace(/[\/\\]+/g, ':'); // replace slashes by `:`
 
-  if (scope){
+  if (scope) {
     ns = scope + '/' + ns;
   }
 

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -150,18 +150,6 @@ Environment.prototype.register = function register(name, namespace) {
     return this.error(new Error('Unable to determine namespace.'));
   }
 
-  var folders = name.split(path.sep);
-  var master = namespace.split(':')[0];
-  for (var i = 0, l = folders.length; i < l; i++) {
-    if (folders[i].indexOf('generator-' + master) !== -1){
-      break;
-    }
-  }
-
-  if (folders[i - 1].indexOf('@') !== -1) {
-    namespace = folders[i - 1] + '/' + namespace;
-  }
-
   this.store.add(namespace, modulePath);
 
   debug('Registered %s (%s)', namespace, modulePath);
@@ -390,11 +378,11 @@ Environment.prototype.namespace = function namespace(filepath) {
     .replace(/^[\/\\]+/, '') // remove leading `/`
     .replace(/[\/\\]+/g, ':'); // replace slashes by `:`
 
-  debug('Resolve namespaces for %s: %s', filepath, ns);
-
   if (scope){
     ns = scope + '/' + ns;
   }
+
+  debug('Resolve namespaces for %s: %s', filepath, ns);
 
   return ns;
 };
@@ -426,7 +414,7 @@ Environment.enforceUpdate = function (env) {
   }
   if (!env.runLoop) {
     env.runLoop = new GroupedQueue(['initializing', 'prompting', 'configuring', 'default',
-    'writing', 'conflicts', 'install', 'end']);
+      'writing', 'conflicts', 'install', 'end']);
   }
   if (!env.sharedFs) {
     env.sharedFs = memFs.create();

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -150,6 +150,18 @@ Environment.prototype.register = function register(name, namespace) {
     return this.error(new Error('Unable to determine namespace.'));
   }
 
+  var folders = name.split(path.sep);
+  var master = namespace.split(':')[0];
+  for (var i = 0, l = folders.length; i < l; i++) {
+    if (folders[i].indexOf('generator-' + master) !== -1){
+      break;
+    }
+  }
+
+  if (folders[i - 1].indexOf('@') !== -1) {
+    namespace = folders[i - 1] + '/' + namespace;
+  }
+
   this.store.add(namespace, modulePath);
 
   debug('Registered %s (%s)', namespace, modulePath);

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -63,6 +63,10 @@ resolver.findGeneratorsIn = function (searchPaths) {
 
   searchPaths.forEach(function (root) {
     if (!root) return;
+    modules = glob.sync('@*', {cwd: root, stat: true}).reduce(function(acum, current){
+      var results = resolver.findGeneratorsIn([path.join(root, current)]);
+      return results.concat(acum);
+    }, modules);
     var found = glob.sync('generator-*', { cwd: root, stat: true }).map(function (match) {
       return path.join(root, match);
     });

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -63,11 +63,9 @@ resolver.findGeneratorsIn = function (searchPaths) {
 
   searchPaths.forEach(function (root) {
     if (!root) return;
-    modules = glob.sync('@*', {cwd: root, stat: true}).reduce(function(acum, current){
-      var results = resolver.findGeneratorsIn([path.join(root, current)]);
-      return results.concat(acum);
-    }, modules);
-    var found = glob.sync('generator-*', { cwd: root, stat: true }).map(function (match) {
+    var found = glob.sync('generator-*', { cwd: root, stat: true });
+    found = found.concat(glob.sync('@*/generator-*', { cwd: root, stat: true }));
+    found = found.map(function (match) {
       return path.join(root, match);
     });
     modules = found.concat(modules);

--- a/test/environment.js
+++ b/test/environment.js
@@ -83,10 +83,15 @@ describe('Environment', function () {
       this.Generator = yeoman.generators.Base.extend();
       this.env.registerStub(this.Generator, 'stub');
       this.env.registerStub(this.Generator, 'stub:foo:bar');
+      this.env.registerStub(this.Generator, '@scope/stub');
     });
 
     it('instantiate a generator', function () {
       assert.ok(this.env.create('stub') instanceof this.Generator);
+    });
+
+    it('instantiate a scoped generator', function () {
+      assert.ok(this.env.create('@scope/stub') instanceof this.Generator);
     });
 
     it('pass options.arguments', function () {

--- a/test/environment.js
+++ b/test/environment.js
@@ -348,6 +348,13 @@ describe('Environment', function () {
       assert.equal(this.env.namespace('node_modules/generator-mocha/backbone/model.js'), 'mocha:backbone:model');
     });
 
+    it('create namespace from scoped path', function () {
+      assert.equal(this.env.namespace('@dummyscope/generator-backbone/all.js'), '@dummyscope/backbone:all');
+      assert.equal(this.env.namespace('@dummyscope/generator-mocha/backbone/model/index.js'), '@dummyscope/mocha:backbone:model');
+      assert.equal(this.env.namespace('@dummyscope/generator-mocha/backbone/model.js'), '@dummyscope/mocha:backbone:model');
+      assert.equal(this.env.namespace('/node_modules/@dummyscope/generator-mocha/backbone/model.js'), '@dummyscope/mocha:backbone:model');
+    });
+
     it('handle relative paths', function () {
       assert.equal(this.env.namespace('../local/stuff'), 'local:stuff');
       assert.equal(this.env.namespace('./local/stuff'), 'local:stuff');

--- a/test/fixtures/custom-generator-scoped/app/index.js
+++ b/test/fixtures/custom-generator-scoped/app/index.js
@@ -1,0 +1,2 @@
+var yeoman = require('yeoman-generator');
+module.exports = yeoman.generators.NamedBase.extend();

--- a/test/fixtures/custom-generator-scoped/app/scaffold/main.js
+++ b/test/fixtures/custom-generator-scoped/app/scaffold/main.js
@@ -1,0 +1,2 @@
+var yeoman = require('yeoman-generator');
+module.exports = yeoman.generators.NamedBase.extend();

--- a/test/fixtures/custom-generator-scoped/package.json
+++ b/test/fixtures/custom-generator-scoped/package.json
@@ -1,0 +1,12 @@
+{
+  "author": "",
+  "name": "custom-generator-scoped",
+  "version": "0.0.0",
+  "main": "app/scaffold/main.js",
+  "dependencies": {},
+  "devDependencies": {},
+  "optionalDependencies": {},
+  "engines": {
+    "node": "*"
+  }
+}

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -12,6 +12,9 @@ describe('Environment Resolver', function () {
   this.timeout(100000);
 
   describe('#lookup()', function () {
+    var scopedFolder = path.resolve('./node_modules/@dummyscope');
+    var scopedGenerator = path.join(scopedFolder, 'generator-scoped');
+
     before(function () {
       this.projectRoot = path.join(__dirname, 'fixtures/lookup-project');
       process.chdir(this.projectRoot);
@@ -24,10 +27,24 @@ describe('Environment Resolver', function () {
         path.resolve('./node_modules/generator-extend'),
         'dir'
       );
+
+      if (!fs.existsSync(scopedFolder)) {
+        fs.mkdirSync(scopedFolder);
+      }
+
+      if(!fs.existsSync(scopedGenerator)) {
+        fs.symlinkSync(
+          path.resolve('../custom-generator-scoped'),
+          scopedGenerator,
+          'dir'
+        );
+      }
     });
 
     after(function () {
       fs.unlinkSync(path.join(this.projectRoot, './node_modules/generator-extend'));
+      fs.unlinkSync(scopedGenerator);
+      fs.rmdirSync(scopedFolder);
       process.chdir(__dirname);
     });
 
@@ -40,7 +57,10 @@ describe('Environment Resolver', function () {
     it('register local generators', function () {
       assert.ok(this.env.get('dummy:app'));
       assert.ok(this.env.get('dummy:yo'));
+      assert.ok(this.env.get('@dummyscope/scoped:app'));
     });
+
+    return;
 
     it('register non-dependency local generator', function () {
       assert.ok(this.env.get('jquery:app'));
@@ -48,7 +68,7 @@ describe('Environment Resolver', function () {
 
     if (!process.env.NODE_PATH) {
       console.log('Skipping tests for global generators. Please setup `NODE_PATH` ' +
-        'environment variable to run it.');
+      'environment variable to run it.');
     }
 
     it('local generators prioritized over global', function () {
@@ -68,7 +88,7 @@ describe('Environment Resolver', function () {
       before(function () {
         this.projectSubRoot = path.join(this.projectRoot, 'subdir');
         process.chdir(this.projectSubRoot);
-        shell.exec('npm install', { silent: true });
+        shell.exec('npm install', {silent: true});
       });
 
       beforeEach(function () {

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -32,7 +32,7 @@ describe('Environment Resolver', function () {
         fs.mkdirSync(scopedFolder);
       }
 
-      if(!fs.existsSync(scopedGenerator)) {
+      if (!fs.existsSync(scopedGenerator)) {
         fs.symlinkSync(
           path.resolve('../custom-generator-scoped'),
           scopedGenerator,
@@ -57,10 +57,11 @@ describe('Environment Resolver', function () {
     it('register local generators', function () {
       assert.ok(this.env.get('dummy:app'));
       assert.ok(this.env.get('dummy:yo'));
-      assert.ok(this.env.get('@dummyscope/scoped:app'));
     });
 
-    return;
+    it('register generators in scoped packages', function () {
+      assert.ok(this.env.get('@dummyscope/scoped:app'));
+    });
 
     it('register non-dependency local generator', function () {
       assert.ok(this.env.get('jquery:app'));
@@ -68,7 +69,7 @@ describe('Environment Resolver', function () {
 
     if (!process.env.NODE_PATH) {
       console.log('Skipping tests for global generators. Please setup `NODE_PATH` ' +
-      'environment variable to run it.');
+        'environment variable to run it.');
     }
 
     it('local generators prioritized over global', function () {
@@ -88,7 +89,7 @@ describe('Environment Resolver', function () {
       before(function () {
         this.projectSubRoot = path.join(this.projectRoot, 'subdir');
         process.chdir(this.projectSubRoot);
-        shell.exec('npm install', {silent: true});
+        shell.exec('npm install', { silent: true });
       });
 
       beforeEach(function () {


### PR DESCRIPTION
This is the easiest way to look for scoped packages. It does not use the scope name when calling yo (so not what @SBoudrias expects in https://github.com/yeoman/yo/issues/231).
I'll see if I can make the other version and then you can decide which one to use.