### PR TITLE
Fix namespace resolution for paths with more than one '.js' in it

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -357,7 +357,7 @@ Environment.prototype.namespace = function namespace(filepath) {
   }
 
   // cleanup extension and normalize path for differents OS
-  var ns = path.normalize(filepath.replace(path.extname(filepath), ''));
+  var ns = path.normalize(filepath.replace(new RegExp(path.extname(filepath) + '$'), ''));
 
   // Sort lookups by length so biggest are removed first
   var lookups = _(this.lookups).map(path.normalize).sortBy('length').value().reverse();


### PR DESCRIPTION
* This bug is not an io.js issue but really an issue with any module
  path that has more than one '.js' in its path.  Since io.js is
  typically installed into a directory called 'io.js', if you have a
  generator path of
  /path/to/io.js/node_modules/lib/generators/yo/index.js, the first
  occurance of '.js' was replaced instread of the '.js' in 'index.js'.

Fixes #30