### PR TITLE
Make namespace resolution safer

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -357,7 +357,7 @@ Environment.prototype.namespace = function namespace(filepath) {
   }
 
   // cleanup extension and normalize path for differents OS
-  var ns = path.normalize(filepath.replace(new RegExp(path.extname(filepath) + '$'), ''));
+  var ns = path.normalize(filepath.replace(new RegExp(escapeStrRe(path.extname(filepath)) + '$'), ''));
 
   // Sort lookups by length so biggest are removed first
   var lookups = _(this.lookups).map(path.normalize).sortBy('length').value().reverse();


### PR DESCRIPTION
* Instead of blindly turning a file extension into a RegExp, we now
  escape the input using `escape-string-regexp`.  Since it was already
  in use, it was a non-issue.

* This is a follow up to #31.  #31 fixed the immediate problem but left
  yeoman-environment in the same state it was before.  This should make
  namespace resolution safer.
