### PR TITLE
Don't print `\n` when no argument in `write()`

### DIFF
--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -77,15 +77,10 @@ module.exports = function logger() {
 
   _.extend(log, events.EventEmitter.prototype);
 
-  // A simple write method, with formatted message. If `msg` is
-  // ommitted, then a single `\n` is written.
+  // A simple write method, with formatted message.
   //
   // Returns the logger
-  log.write = function (msg) {
-    if (!msg) {
-      return this.write('\n');
-    }
-
+  log.write = function () {
     process.stderr.write(util.format.apply(util, arguments));
     return this;
   };
@@ -93,7 +88,9 @@ module.exports = function logger() {
   // Same as `log.write()` but automatically appends a `\n` at the end
   // of the message.
   log.writeln = function () {
-    return this.write.apply(this, arguments).write();
+    this.write.apply(this, arguments);
+    this.write('\n');
+    return this;
   };
 
   // Convenience helper to write sucess status, this simply prepends the


### PR DESCRIPTION
Fix #6 