### PR TITLE
Fix traceback displayed when using invalid generator name

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -245,7 +245,7 @@ Environment.prototype.create = function create(namespace, options) {
 
   var Generator = this.get(namespace);
 
-  if (!Generator) {
+  if (!_.isFunction(Generator)) {
     return this.error(
       new Error(
         'You don\'t seem to have a generator with the name ' + namespace + ' installed.\n' +


### PR DESCRIPTION
Particularly when using a command like `yo foo:bar`