### PR TITLE
fix(env#namespace): only remove `lookups` that match full directory name

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -375,11 +375,13 @@ Environment.prototype.namespace = function namespace(filepath) {
   var ns = path.normalize(filepath.replace(new RegExp(escapeStrRe(path.extname(filepath)) + '$'), ''));
 
   // Sort lookups by length so biggest are removed first
-  var lookups = _(this.lookups).map(path.normalize).sortBy('length').value().reverse();
+  var lookups = _(this.lookups.concat(['..'])).map(path.normalize).sortBy('length').value().reverse();
 
   // if `ns` contains a lookup dir in its path, remove it.
   ns = lookups.reduce(function (ns, lookup) {
-    return ns.replace(new RegExp(escapeStrRe(lookup), 'g'), '');
+    // only match full directory (begin with leading slash or start of input, end with trailing slash)
+    lookup = new RegExp('(?:\\\\|/|^)' + escapeStrRe(lookup) + '(?=\\\\|/)', 'g');
+    return ns.replace(lookup, '');
   }, ns);
 
   var folders = ns.split(path.sep);
@@ -391,7 +393,6 @@ Environment.prototype.namespace = function namespace(filepath) {
   ns = ns
     .replace(/(.*generator-)/, '') // remove before `generator-`
     .replace(/[\/\\](index|main)$/, '') // remove `/index` or `/main`
-    .replace(/\.+/g, '') // remove `.`
     .replace(/^[\/\\]+/, '') // remove leading `/`
     .replace(/[\/\\]+/g, ':'); // replace slashes by `:`
 

--- a/test/environment.js
+++ b/test/environment.js
@@ -395,6 +395,9 @@ describe('Environment', function () {
     it('remove lookups from namespace', function () {
       assert.equal(this.env.namespace('backbone/generators/all/index.js'), 'backbone:all');
       assert.equal(this.env.namespace('backbone/lib/generators/all/index.js'), 'backbone:all');
+      assert.equal(this.env.namespace('some-lib/generators/all/index.js'), 'some-lib:all');
+      assert.equal(this.env.namespace('my.thing/generators/app/index.js'), 'my.thing:app');
+      assert.equal(this.env.namespace('meta/generators/generators-thing/index.js'), 'meta:generators-thing');
     });
 
     it('remove path before the generator name', function () {


### PR DESCRIPTION
The existing method of removing sub-generator `lookup` patterns from the path created unexpected results in a few corner cases:

- `my-lib/generators/app` => `my-:app`, instead of `my-lib:app`
- `my.lib/generators/app` => `mylib:app`, instead of `my.lib:app`
- `test/generators/generators-thing` => `test:-thing`