### PR TITLE
Add shared storage for generators.

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -10,6 +10,7 @@ var escapeStrRe = require('escape-string-regexp');
 var untildify = require('untildify');
 var memFs = require('mem-fs');
 var debug = require('debug')('yeoman:environment');
+var Map = require('es6-map');
 var Store = require('./store');
 var resolver = require('./resolver');
 var TerminalAdapter = require('./adapter');
@@ -54,6 +55,7 @@ var Environment = module.exports = function Environment(args, opts, adapter) {
   // Node won't complain about event listeners leaks.
   this.runLoop.setMaxListeners(0);
   this.sharedFs.setMaxListeners(0);
+  this.shared = new Map();
 
   this.lookups = ['.', 'generators', 'lib/generators'];
   this.aliases = [];

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "chalk": "^1.0.0",
     "debug": "^2.0.0",
     "diff": "^2.1.2",
+    "es6-map": "^0.1.3",
     "escape-string-regexp": "^1.0.2",
     "globby": "^4.0.0",
     "grouped-queue": "^0.3.0",


### PR DESCRIPTION
This is so sub-generators (or a collection of similarly-authored generators) can depend on shared data if needed...  It relies on a module already in the dependency tree (dependency of a dependency) and is a small addition that enables a powerful subset style of generating, so I see no harm done.

Say for instance, I have `foo`, with `foo:bar` and `foo:qux` that both render different files that require `name`...  If we run these at the same time:
```shell
$ yo foo:bar, foo:qux
```
You can prompt for the data one time (both generators `foo:bar` and `foo:qux`):
```javascript
prompting: function() {
  if (!this.env.share.has('name')) {
    this.prompt({ ... }, function(res) {
      this.env.share.set('name', res.name);
    });
  }
}
```

Yet both generators can still retrieve the name later, with `this.env.shared.get('name')`, without having to reprompt the user.

The module I used, `es6-map`, was already in the dep tree, so I'm just reusing it here in a small implementation.

Closes https://github.com/yeoman/yo/issues/416