### PR TITLE
Add NVM prefix if NVM_PATH is defined

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -109,6 +109,11 @@ resolver._tryRegistering = function (generatorReference) {
 resolver.getNpmPaths = function () {
   var paths = [];
 
+  // Add NVM prefix directory
+  if (process.env.NVM_PATH) {
+    paths.push(path.join(path.dirname(process.env.NVM_PATH), 'node_modules'));
+  }
+
   // Adding global npm directories
   // We tried using npm to get the global modules path, but it haven't work out
   // because of bugs in the parseable implementation of `ls` command and mostly

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -119,64 +119,93 @@ describe('Environment Resolver', function () {
       process.env.NODE_PATH = this.NODE_PATH;
     });
 
-    describe('with NODE_PATH', testWith('NODE_PATH'));
-    describe('without NODE_PATH', testWithout('NODE_PATH'));
-    describe('with NVM_PATH', testWith('NVM_PATH', true));
-    describe('without NVM_PATH', testWithout('NVM_PATH', true));
+    describe('with NODE_PATH', function () {
+      beforeEach(function () {
+        process.env.NODE_PATH = '/some/dummy/path';
+      });
 
-    function testWith(env, dirname) {
-      return function () {
-        beforeEach(function () {
-          process.env[env] = '/some/dummy/path';
-          this.dirname = path.join(path.dirname(process.env[env]), 'node_modules');
-        });
+      afterEach(function () {
+        delete process.env.NODE_PATH;
+      });
 
-        afterEach(function () {
-          delete process.env[env];
-        });
+      it('walk up the CWD lookups dir', function () {
+        var paths = this.env.getNpmPaths();
+        assert.equal(paths[0], path.join(process.cwd(), 'node_modules'));
+        var prevdir = process.cwd().split(path.sep).slice(0, -1).join(path.sep);
+        assert.equal(paths[1], path.join(prevdir, 'node_modules'));
+      });
 
-        it('walk up the CWD lookups dir', function () {
-          var paths = this.env.getNpmPaths();
-          assert.equal(paths[0], path.join(process.cwd(), 'node_modules'));
-          var prevdir = process.cwd().split(path.sep).slice(0, -1).join(path.sep);
-          assert.equal(paths[1], path.join(prevdir, 'node_modules'));
-        });
+      it('append NODE_PATH', function () {
+        assert(this.env.getNpmPaths().indexOf(process.env.NODE_PATH) >= 0);
+      });
+    });
 
-        it('append ' + env, function () {
-          assert(this.env.getNpmPaths().indexOf(dirname ? this.dirname : process.env[env]) >= 0);
-        });
-      };
-    }
+    describe('without NODE_PATH', function () {
+      beforeEach(function () {
+        delete process.env.NODE_PATH;
+      });
 
-    function testWithout(env, dirname) {
-      return function () {
-        beforeEach(function () {
-          process.env[env] = '';
-          process.env.NODE_PATH = '';
-          this.bestBet = dirname ? path.join(path.dirname(this.bestBet), 'node_modules') : this.bestBet;
-          this.bestBet = dirname ? path.join(path.dirname(this.bestBet), 'node_modules') : this.bestBet;
-        });
+      it('walk up the CWD lookups dir', function () {
+        var paths = this.env.getNpmPaths();
+        assert.equal(paths[0], path.join(process.cwd(), 'node_modules'));
+        var prevdir = process.cwd().split(path.sep).slice(0, -1).join(path.sep);
+        assert.equal(paths[1], path.join(prevdir, 'node_modules'));
+      });
 
-        it('walk up the CWD lookups dir', function () {
-          var paths = this.env.getNpmPaths();
-          assert.equal(paths[0], path.join(process.cwd(), 'node_modules'));
-          var prevdir = process.cwd().split(path.sep).slice(0, -1).join(path.sep);
-          assert.equal(paths[1], path.join(prevdir, 'node_modules'));
-        });
+      it('append best bet if NODE_PATH is unset', function () {
+        assert(this.env.getNpmPaths().indexOf(this.bestBet) >= 0);
+        assert(this.env.getNpmPaths().indexOf(this.bestBet2) >= 0);
+      });
 
-        it('append best bet if ' + env + ' is unset', function () {
-          assert(this.env.getNpmPaths().indexOf(this.bestBet) >= 0);
-          assert(this.env.getNpmPaths().indexOf(this.bestBet2) >= 0);
-        });
+      it('append default NPM dir depending on your OS', function () {
+        if (process.platform === 'win32') {
+          assert(this.env.getNpmPaths().indexOf(path.join(process.env.APPDATA, 'npm/node_modules')) >= 0);
+        } else {
+          assert(this.env.getNpmPaths().indexOf('/usr/lib/node_modules') >= 0);
+        }
+      });
+    });
 
-        it('append default NPM dir depending on your OS', function () {
-          if (process.platform === 'win32') {
-            assert(this.env.getNpmPaths().indexOf(path.join(process.env.APPDATA, 'npm/node_modules')) >= 0);
-          } else {
-            assert(this.env.getNpmPaths().indexOf('/usr/lib/node_modules') >= 0);
-          }
-        });
-      };
-    }
+    describe('with NVM_PATH', function () {
+      beforeEach(function () {
+        process.env.NVM_PATH = '/some/dummy/path';
+        this.dirname = path.join(path.dirname(process.env.NVM_PATH), 'node_modules');
+      });
+
+      afterEach(function () {
+        delete process.env.NVM_PATH;
+      });
+
+      it('walk up the CWD lookups dir', function () {
+        var paths = this.env.getNpmPaths();
+        assert.equal(paths[0], path.join(process.cwd(), 'node_modules'));
+        var prevdir = process.cwd().split(path.sep).slice(0, -1).join(path.sep);
+        assert.equal(paths[1], path.join(prevdir, 'node_modules'));
+      });
+
+      it('append NVM_PATH', function () {
+        assert(this.env.getNpmPaths().indexOf(this.dirname) >= 0);
+      });
+    });
+
+    describe('without NVM_PATH', function () {
+      beforeEach(function () {
+        delete process.env.NVM_PATH;
+        this.dirname = path.join(this.bestBet, 'node_modules');
+      });
+
+      it('walk up the CWD lookups dir', function () {
+        var paths = this.env.getNpmPaths();
+        assert.equal(paths[0], path.join(process.cwd(), 'node_modules'));
+        var prevdir = process.cwd().split(path.sep).slice(0, -1).join(path.sep);
+        assert.equal(paths[1], path.join(prevdir, 'node_modules'));
+      });
+
+      it('append best bet if NVM_PATH is unset', function () {
+        assert(this.env.getNpmPaths().indexOf(this.dirname) >= 0);
+        assert(this.env.getNpmPaths().indexOf(this.bestBet2) >= 0);
+      });
+    });
+
   });
 });

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -131,8 +131,7 @@ describe('Environment Resolver', function () {
       it('walk up the CWD lookups dir', function () {
         var paths = this.env.getNpmPaths();
         assert.equal(paths[0], path.join(process.cwd(), 'node_modules'));
-        var prevdir = process.cwd().split(path.sep).slice(0, -1).join(path.sep);
-        assert.equal(paths[1], path.join(prevdir, 'node_modules'));
+        assert.equal(paths[1], path.join(process.cwd(), '../node_modules'));
       });
 
       it('append NODE_PATH', function () {
@@ -169,7 +168,6 @@ describe('Environment Resolver', function () {
     describe('with NVM_PATH', function () {
       beforeEach(function () {
         process.env.NVM_PATH = '/some/dummy/path';
-        this.dirname = path.join(path.dirname(process.env.NVM_PATH), 'node_modules');
       });
 
       afterEach(function () {
@@ -179,12 +177,11 @@ describe('Environment Resolver', function () {
       it('walk up the CWD lookups dir', function () {
         var paths = this.env.getNpmPaths();
         assert.equal(paths[0], path.join(process.cwd(), 'node_modules'));
-        var prevdir = process.cwd().split(path.sep).slice(0, -1).join(path.sep);
-        assert.equal(paths[1], path.join(prevdir, 'node_modules'));
+        assert.equal(paths[1], path.join(process.cwd(), '../node_modules'));
       });
 
       it('append NVM_PATH', function () {
-        assert(this.env.getNpmPaths().indexOf(this.dirname) >= 0);
+        assert(this.env.getNpmPaths().indexOf(path.join(path.dirname(process.env.NVM_PATH), 'node_modules')) >= 0);
       });
     });
 
@@ -197,8 +194,7 @@ describe('Environment Resolver', function () {
       it('walk up the CWD lookups dir', function () {
         var paths = this.env.getNpmPaths();
         assert.equal(paths[0], path.join(process.cwd(), 'node_modules'));
-        var prevdir = process.cwd().split(path.sep).slice(0, -1).join(path.sep);
-        assert.equal(paths[1], path.join(prevdir, 'node_modules'));
+        assert.equal(paths[1], path.join(process.cwd(), '../node_modules'));
       });
 
       it('append best bet if NVM_PATH is unset', function () {

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -132,7 +132,7 @@ describe('Environment Resolver', function () {
         });
 
         afterEach(function () {
-          process.env[env] = '';
+          delete process.env[env];
         });
 
         it('walk up the CWD lookups dir', function () {

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -188,7 +188,6 @@ describe('Environment Resolver', function () {
     describe('without NVM_PATH', function () {
       beforeEach(function () {
         delete process.env.NVM_PATH;
-        this.dirname = path.join(this.bestBet, 'node_modules');
       });
 
       it('walk up the CWD lookups dir', function () {
@@ -198,7 +197,7 @@ describe('Environment Resolver', function () {
       });
 
       it('append best bet if NVM_PATH is unset', function () {
-        assert(this.env.getNpmPaths().indexOf(this.dirname) >= 0);
+        assert(this.env.getNpmPaths().indexOf(path.join(this.bestBet, 'node_modules')) >= 0);
         assert(this.env.getNpmPaths().indexOf(this.bestBet2) >= 0);
       });
     });


### PR DESCRIPTION
As discussed in #59

Added tests for `with NVM_PATH` / `without NVM_PATH` that checks the same things `NODE_PATH` checks, not sure if it's good enough but it covers the case of NVM_PATH being defined.