### PR TITLE
Downgrade untildify

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "log-symbols": "^1.0.1",
     "mem-fs": "^1.1.0",
     "text-table": "^0.2.0",
-    "untildify": "^3.0.1"
+    "untildify": "^2.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.6",


### PR DESCRIPTION
Untildify 3.0.0 breaks compatibility with Node 0.10 and 0.12. Downgrading to
2.0.0 restores it.

Fixes #61