### PR TITLE
Improved handling of win32 abs paths when executing a generator by path.

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -230,20 +230,22 @@ Environment.prototype.getGeneratorNames = function getGeneratorNames() {
  * get `angular:common:all` then we get `angular:common` as a fallback (unless
  * an `angular:common:all` generator is registered).
  *
- * @param  {String} namespace
+ * @param  {String} namespaceOrPath
  * @return {Generator|null} - the generator registered under the namespace
  */
 
-Environment.prototype.get = function get(namespace) {
+Environment.prototype.get = function get(namespaceOrPath) {
   // Stop the recursive search if nothing is left
-  if (!namespace) {
+  if (!namespaceOrPath) {
     return;
   }
+
+  var namespace = namespaceOrPath;
 
   // Legacy yeoman-generator `#hookFor()` function is passing the generator path as part
   // of the namespace. If we find a path delimiter in the namespace, then ignore the
   // last part of the namespace.
-  var parts = namespace.split(':');
+  var parts = namespaceOrPath.split(':');
   var maybePath = _.last(parts);
   if (parts.length > 1 && /[\/\\]/.test(maybePath)) {
     parts.pop();
@@ -253,17 +255,14 @@ Environment.prototype.get = function get(namespace) {
       parts.pop();
     }
 
-    // If the parts collection is empty at this point,
-    // it is likely namespace contains a win32 absolute path of the form 'C:\path\to\generator'.
-    // In such a case we want to preserve namepsace's value - so the getByPath function can properly handle it.  
-    if (parts.length > 0) {
-      namespace = parts.join(':');
-    }
+    namespace = parts.join(':');
   }
 
   return this.store.get(namespace) ||
     this.store.get(this.alias(namespace)) ||
-    this.getByPath(namespace);
+    // namespace is empty if namespaceOrPath contains a win32 absolute path of the form 'C:\path\to\generator'.
+    // for this reason we pass namespaceOrPath to the getByPath function.
+    this.getByPath(namespaceOrPath);
 };
 
 /**

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -253,7 +253,12 @@ Environment.prototype.get = function get(namespace) {
       parts.pop();
     }
 
-    namespace = parts.join(':');
+    // If the parts collection is empty at this point,
+    // it is likely namespace contains a win32 absolute path of the form 'C:\path\to\generator'.
+    // In such a case we want to preserve namepsace's value - so the getByPath function can properly handle it.  
+    if (parts.length > 0) {
+      namespace = parts.join(':');
+    }
   }
 
   return this.store.get(namespace) ||

--- a/test/environment.js
+++ b/test/environment.js
@@ -431,6 +431,38 @@ describe('Environment', function () {
       assert.equal(this.env.get('mocha:generator:C:\\foo\\bar'), this.generator);
     });
 
+    it('works with Windows\' absolute paths', function() {
+      var getMethod;
+      var aliasMethod;
+      var getByPathMethod;
+
+      var absolutePaht = 'C:\\foo\\bar'; 
+
+      try
+      {
+        getMethod = sinon.stub(this.env.store, 'get').returns(null);
+        aliasMethod = sinon.stub(this.env, 'alias').returns("");
+        getByPathMethod = sinon.stub(this.env, 'getByPath').returns(null);
+
+        this.env.get(absolutePaht);
+
+        assert.ok(getMethod.calledTwice);
+        assert.ok(getMethod.alwaysCalledWithExactly(""));
+
+        assert.ok(aliasMethod.calledOnce);
+        assert.ok(aliasMethod.calledWithExactly(""));
+
+        assert.ok(getByPathMethod.calledOnce);
+        assert.ok(getByPathMethod.calledWithExactly(absolutePaht));
+      }
+      finally
+      {
+        getMethod.restore();
+        aliasMethod.restore();
+        getByPathMethod.restore();
+      }
+    });
+
     it('fallback to requiring generator from a file path', function () {
       assert.equal(
         this.env.get(path.join(__dirname, './fixtures/generator-mocha')),

--- a/test/environment.js
+++ b/test/environment.js
@@ -431,37 +431,21 @@ describe('Environment', function () {
       assert.equal(this.env.get('mocha:generator:C:\\foo\\bar'), this.generator);
     });
 
-    it('works with Windows\' absolute paths', function() {
-      var getMethod;
-      var aliasMethod;
-      var getByPathMethod;
+    it('works with Windows\' absolute paths', sinon.test(function() {
+        var absolutePath = 'C:\\foo\\bar'; 
 
-      var absolutePaht = 'C:\\foo\\bar'; 
+        var envMock = this.mock(this.env);
 
-      try
-      {
-        getMethod = sinon.stub(this.env.store, 'get').returns(null);
-        aliasMethod = sinon.stub(this.env, 'alias').returns("");
-        getByPathMethod = sinon.stub(this.env, 'getByPath').returns(null);
+        envMock
+          .expects("getByPath")
+          .once()
+          .withExactArgs(absolutePath)
+          .returns(null);
 
-        this.env.get(absolutePaht);
+        this.env.get(absolutePath);
 
-        assert.ok(getMethod.calledTwice);
-        assert.ok(getMethod.alwaysCalledWithExactly(""));
-
-        assert.ok(aliasMethod.calledOnce);
-        assert.ok(aliasMethod.calledWithExactly(""));
-
-        assert.ok(getByPathMethod.calledOnce);
-        assert.ok(getByPathMethod.calledWithExactly(absolutePaht));
-      }
-      finally
-      {
-        getMethod.restore();
-        aliasMethod.restore();
-        getByPathMethod.restore();
-      }
-    });
+        envMock.verify();
+    }));
 
     it('fallback to requiring generator from a file path', function () {
       assert.equal(


### PR DESCRIPTION
Hi!

This pull request makes it possible to say:
```
yo D:\src\projects\vscode-generator-code\generators\app
```

Useful for debugging of generators.

Thank you,
Mykola.