### PR TITLE
getNpmPaths default path for Mac OS

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -136,6 +136,7 @@ resolver.getNpmPaths = function () {
     paths.push(path.join(process.env.APPDATA, 'npm/node_modules'));
   } else {
     paths.push('/usr/lib/node_modules');
+    paths.push('/usr/local/lib/node_modules');
   }
 
   // Walk up the CWD and add `node_modules/` folder lookup on each level


### PR DESCRIPTION
Have a problem with lookup function on Mac OS.
getNpmPaths is looking for generators in node_modules at
'/usr/lib/node_modules' path, but also there is another path for
node_modules on mac: '/usr/local/lib/node_modules'.