### PR TITLE
Support for multi-word command line arguments

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -107,7 +107,7 @@ class Environment extends EventEmitter {
     super();
 
     args = args || [];
-    this.arguments = Array.isArray(args) ? args : args.split(' ');
+    this.arguments = Array.isArray(args) ? args : this.splitArgsFromString(args);
     this.options = opts || {};
     this.adapter = adapter || new TerminalAdapter();
     this.cwd = this.options.cwd || process.cwd();
@@ -376,7 +376,7 @@ class Environment extends EventEmitter {
     options = options || {};
 
     let args = options.arguments || options.args || _.clone(this.arguments);
-    args = Array.isArray(args) ? args : args.split(' ');
+    args = Array.isArray(args) ? args : this.splitArgsFromString(args);
 
     const opts = options.options || _.clone(this.options);
 
@@ -410,7 +410,7 @@ class Environment extends EventEmitter {
       args = this.arguments;
     }
 
-    args = Array.isArray(args) ? args : args.split(' ');
+    args = Array.isArray(args) ? args : this.splitArgsFromString(args);
     options = options || this.options;
 
     const name = args.shift();
@@ -505,6 +505,19 @@ class Environment extends EventEmitter {
     }
 
     return require.resolve(untildify(moduleId));
+  }
+
+  splitArgsFromString(argsString) {
+    let result = [];
+    const quoteSeparatedArgs = argsString.split(/(\x22[^\x22]*\x22)/).filter(x => x);
+    quoteSeparatedArgs.forEach(arg => {
+      if (arg.match('\x22')) {
+        result.push(arg.replace(/\x22/g, ''));
+      } else {
+        result = result.concat(arg.trim().split(' '));
+      }
+    });
+    return result;
   }
 }
 

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -15,6 +15,23 @@ const resolver = require('./resolver');
 const TerminalAdapter = require('./adapter');
 
 /**
+ * Two-step argument splitting function that first splits arguments in quotes,
+ * and then splits up the remaining arguments if they are not part of a quote.
+ */
+function splitArgsFromString(argsString) {
+  let result = [];
+  const quoteSeparatedArgs = argsString.split(/(\x22[^\x22]*\x22)/).filter(x => x);
+  quoteSeparatedArgs.forEach(arg => {
+    if (arg.match('\x22')) {
+      result.push(arg.replace(/\x22/g, ''));
+    } else {
+      result = result.concat(arg.trim().split(' '));
+    }
+  });
+  return result;
+}
+
+/**
  * `Environment` object is responsible of handling the lifecyle and bootstrap
  * of generators in a specific environment (your app).
  *
@@ -107,7 +124,7 @@ class Environment extends EventEmitter {
     super();
 
     args = args || [];
-    this.arguments = Array.isArray(args) ? args : this.splitArgsFromString(args);
+    this.arguments = Array.isArray(args) ? args : splitArgsFromString(args);
     this.options = opts || {};
     this.adapter = adapter || new TerminalAdapter();
     this.cwd = this.options.cwd || process.cwd();
@@ -376,7 +393,7 @@ class Environment extends EventEmitter {
     options = options || {};
 
     let args = options.arguments || options.args || _.clone(this.arguments);
-    args = Array.isArray(args) ? args : this.splitArgsFromString(args);
+    args = Array.isArray(args) ? args : splitArgsFromString(args);
 
     const opts = options.options || _.clone(this.options);
 
@@ -410,7 +427,7 @@ class Environment extends EventEmitter {
       args = this.arguments;
     }
 
-    args = Array.isArray(args) ? args : this.splitArgsFromString(args);
+    args = Array.isArray(args) ? args : splitArgsFromString(args);
     options = options || this.options;
 
     const name = args.shift();
@@ -505,19 +522,6 @@ class Environment extends EventEmitter {
     }
 
     return require.resolve(untildify(moduleId));
-  }
-
-  splitArgsFromString(argsString) {
-    let result = [];
-    const quoteSeparatedArgs = argsString.split(/(\x22[^\x22]*\x22)/).filter(x => x);
-    quoteSeparatedArgs.forEach(arg => {
-      if (arg.match('\x22')) {
-        result.push(arg.replace(/\x22/g, ''));
-      } else {
-        result = result.concat(arg.trim().split(' '));
-      }
-    });
-    return result;
   }
 }
 

--- a/test/environment.js
+++ b/test/environment.js
@@ -55,6 +55,11 @@ describe('Environment', () => {
     it('instantiates a mem-fs instance', function () {
       assert.ok(this.env.sharedFs);
     });
+
+    it('takes multi-word arguments', () => {
+      const args = 'foo bar "foo bar" baz "bar foo"';
+      assert.deepEqual(new Environment(args).arguments, ['foo', 'bar', 'foo bar', 'baz', 'bar foo']);
+    });
   });
 
   describe('#help()', () => {


### PR DESCRIPTION
This PR addresses #75 by allowing quote-mark separated command line arguments. It changes the splitting of argument strings to a 2-step process: it first splits the string apart by quotes (any part matching "*"), and then splits parts of the string up further if they are not part of a quote. 