### PR TITLE
Save Generator Version in Environment

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -219,7 +219,7 @@ class Environment extends EventEmitter {
    * @param  {String} namespace - Namespace under which register the generator (optional)
    * @return {String} namespace - Namespace assigned to the registered generator
    */
-  register(name, namespace) {
+  register(name, namespace, packageJson) {
     if (typeof name !== 'string') {
       return this.error(new Error('You must provide a generator name to register.'));
     }
@@ -231,7 +231,7 @@ class Environment extends EventEmitter {
       return this.error(new Error('Unable to determine namespace.'));
     }
 
-    this.store.add(namespace, modulePath);
+    this.store.add(namespace, modulePath, packageJson);
 
     debug('Registered %s (%s)', namespace, modulePath);
     return this;

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -36,14 +36,14 @@ resolver.lookup = function (cb) {
   const patterns = [];
 
   for (const lookup of this.lookups) {
-    for (const modulePath of generatorsModules) {
-      patterns.push(path.join(modulePath, lookup));
+    for (const module of generatorsModules) {
+      patterns.push(Object.assign({}, module, {path: path.join(module.path, lookup)}));
     }
   }
 
   for (const pattern of patterns) {
-    for (const filename of globby.sync('*/index.js', {cwd: pattern})) {
-      this._tryRegistering(path.join(pattern, filename));
+    for (const filename of globby.sync('*/index.js', {cwd: pattern.path})) {
+      this._tryRegistering(Object.assign({}, pattern, {path: path.join(pattern.path, filename)}));
     }
   }
 
@@ -72,7 +72,11 @@ resolver.findGeneratorsIn = function (searchPaths) {
       'generator-*',
       '@*/generator-*'
     ], {cwd: root})
-      .map(match => path.join(root, match))
+      .map(match => {
+        const generatorPath = path.join(root, match);
+        const packageJson = path.join(generatorPath, 'package.json');
+        return {path: generatorPath, packageJson};
+      })
       .concat(modules);
   }
 
@@ -86,16 +90,18 @@ resolver.findGeneratorsIn = function (searchPaths) {
  */
 resolver._tryRegistering = function (generatorReference) {
   let namespace;
-  const realPath = fs.realpathSync(generatorReference);
+  const generatorPath = generatorReference.path;
+  const packageJson = generatorReference.packageJson;
+  const realPath = fs.realpathSync(generatorPath);
 
   try {
-    debug('found %s, trying to register', generatorReference);
+    debug('found %s, trying to register', generatorPath);
 
-    if (realPath !== generatorReference) {
-      namespace = this.namespace(generatorReference);
+    if (realPath !== generatorPath) {
+      namespace = this.namespace(generatorPath);
     }
 
-    this.register(realPath, namespace);
+    this.register(realPath, namespace, packageJson);
   } catch (err) {
     console.error('Unable to register %s (Error: %s)', generatorReference, err.message);
   }

--- a/lib/store.js
+++ b/lib/store.js
@@ -18,19 +18,23 @@ class Store {
    * @param {String}          namespace - The key under which the generator can be retrieved
    * @param {String|Function} generator - A generator module or a module path
    */
-  add(namespace, generator) {
+  add(namespace, generator, packageJson) {
     if (typeof generator === 'string') {
-      this._storeAsPath(namespace, generator);
+      this._storeAsPath(namespace, generator, packageJson);
       return;
     }
 
-    this._storeAsModule(namespace, generator);
+    this._storeAsModule(namespace, generator, packageJson);
   }
 
-  _storeAsPath(namespace, path) {
+  _storeAsPath(namespace, path, packageJson) {
     this._meta[namespace] = {
       resolved: path,
-      namespace
+      namespace,
+      packageJson,
+      get version() {
+        return require(packageJson).version;
+      }
     };
 
     Object.defineProperty(this._generators, namespace, {
@@ -46,7 +50,9 @@ class Store {
   _storeAsModule(namespace, Generator) {
     this._meta[namespace] = {
       resolved: 'unknown',
-      namespace
+      namespace,
+      packageJson: 'unknown',
+      version: 'unknown'
     };
 
     this._generators[namespace] = Generator;


### PR DESCRIPTION
The first step of [yeoman/yo#542](https://github.com/yeoman/yo/issues/542) involves persisting the generator version # when the Environment is being initialized.  That way we'll have access to it later when we want to display it to the User.