### PR TITLE
Get and run generators exported with exports default

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -355,6 +355,10 @@ class Environment extends EventEmitter {
 
     const Generator = this.get(namespace);
 
+    if (typeof Generator !== 'undefined' && typeof Generator.default === 'function') {
+      return this.instantiate(Generator.default, options);
+    }
+
     if (typeof Generator !== 'function') {
       let generatorHint = '';
       if (isScoped(namespace)) {

--- a/test/environment.js
+++ b/test/environment.js
@@ -258,6 +258,12 @@ describe('Environment', () => {
       });
       this.env.run('@dummyscope/package');
     });
+
+    it('runs a module generator', function () {
+      this.env
+        .register(path.join(__dirname, './fixtures/generator-module/generators/app'), 'fixtures:generator-module');
+      this.env.run('fixtures:generator-module');
+    });
   });
 
   describe('#registerModulePath()', () => {
@@ -480,6 +486,13 @@ describe('Environment', () => {
     it('returns undefined if namespace is not found', function () {
       assert.equal(this.env.get('not:there'), undefined);
       assert.equal(this.env.get(), undefined);
+    });
+
+    it('works with modules', function () {
+      const generator = require('./fixtures/generator-module/generators/app');
+      this.env
+        .register(path.join(__dirname, './fixtures/generator-module/generators/app'), 'fixtures:generator-module');
+      assert.equal(this.env.get('fixtures:generator-module'), generator);
     });
   });
 

--- a/test/fixtures/generator-module/generators/app/index.js
+++ b/test/fixtures/generator-module/generators/app/index.js
@@ -1,0 +1,6 @@
+var Generator = require('yeoman-generator');
+exports.default = class extends Generator {
+  exec() {
+    
+  }
+};

--- a/test/fixtures/generator-module/package.json
+++ b/test/fixtures/generator-module/package.json
@@ -1,0 +1,11 @@
+{
+  "author": "",
+  "name": "generator-module",
+  "version": "0.0.0",
+  "dependencies": {},
+  "devDependencies": {},
+  "optionalDependencies": {},
+  "engines": {
+    "node": "*"
+  }
+}


### PR DESCRIPTION
If generators are exported as modules using `exports default ...` or `exports.default = ...` Yeoman fails to recognize the generator exists because it does not look for it in the `default` property of the module. Only using `module.exports` the generator is recognized, this makes it impossible to run generators transpiled from ES6+. It is also hard to recognize the reason why it fails.

Added 2 regression tests and the fix for this issue.