### PR TITLE
Fix generator error handling (Fix #89)

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -32,6 +32,19 @@ function splitArgsFromString(argsString) {
 }
 
 /**
+ * Wrap callback so it can't get called twice
+ */
+const callbackWrapper = done => {
+  let callbackHandled = false;
+  return err => {
+    if (!callbackHandled && done) {
+      done(err);
+    }
+    callbackHandled = true;
+  };
+};
+
+/**
  * `Environment` object is responsible of handling the lifecyle and bootstrap
  * of generators in a specific environment (your app).
  *
@@ -453,7 +466,11 @@ class Environment extends EventEmitter {
       return console.log(generator.help());
     }
 
-    return generator.run(done);
+    const _callbackWrapper = callbackWrapper(done);
+    // If error was thrown, make sure it is handled and only once
+    generator.on('error', _callbackWrapper);
+
+    return generator.run(_callbackWrapper);
   }
 
   /**
@@ -539,3 +556,4 @@ Object.assign(Environment.prototype, resolver);
 Environment.util = require('./util/util');
 
 module.exports = Environment;
+

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -556,4 +556,3 @@ Object.assign(Environment.prototype, resolver);
 Environment.util = require('./util/util');
 
 module.exports = Environment;
-

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -34,14 +34,20 @@ function splitArgsFromString(argsString) {
 /**
  * Wrap callback so it can't get called twice
  */
-const callbackWrapper = done => {
+const callbackWrapper = (generator, done) => {
+  if (!done) {
+    return _.noop();
+  }
   let callbackHandled = false;
-  return err => {
-    if (!callbackHandled && done) {
+  const callback = err => {
+    if (!callbackHandled) {
+      callbackHandled = true;
       done(err);
     }
-    callbackHandled = true;
   };
+  // If error was thrown, make sure it is handled and only once
+  generator.on('error', callback);
+  return callback;
 };
 
 /**
@@ -466,9 +472,7 @@ class Environment extends EventEmitter {
       return console.log(generator.help());
     }
 
-    const _callbackWrapper = callbackWrapper(done);
-    // If error was thrown, make sure it is handled and only once
-    generator.on('error', _callbackWrapper);
+    const _callbackWrapper = callbackWrapper(generator, done);
 
     return generator.run(_callbackWrapper);
   }

--- a/test/environment.js
+++ b/test/environment.js
@@ -177,8 +177,16 @@ describe('Environment', () => {
         exec() {}
       };
 
+      this.FailingStub = class extends Generator {
+
+        exec() {
+          return Promise.reject(new Error('some error'));
+        }
+      };
+
       this.runMethod = sinon.spy(Generator.prototype, 'run');
       this.env.registerStub(this.Stub, 'stub:run');
+      this.env.registerStub(this.FailingStub, 'failingstub:run');
     });
 
     afterEach(function () {
@@ -246,6 +254,15 @@ describe('Environment', () => {
         done();
       });
       this.env.run('some:unknown:generator');
+    });
+
+    it('generator error calls callback properly', function (done) {
+      this.env.run('failingstub:run', err => {
+        assert.ok(this.runMethod.calledOnce);
+        assert.ok(err instanceof Error);
+        assert.equal(err.message, 'some error');
+        done();
+      });
     });
 
     it('returns the generator', function () {

--- a/test/environment.js
+++ b/test/environment.js
@@ -177,16 +177,24 @@ describe('Environment', () => {
         exec() {}
       };
 
-      this.FailingStub = class extends Generator {
+      this.PromiseFailingStub = class extends Generator {
 
-        exec() {
+        install() {
           return Promise.reject(new Error('some error'));
+        }
+      };
+
+      this.EventFailingStub = class extends Generator {
+
+        install() {
+          return this.emit('error', new Error('some error'));
         }
       };
 
       this.runMethod = sinon.spy(Generator.prototype, 'run');
       this.env.registerStub(this.Stub, 'stub:run');
-      this.env.registerStub(this.FailingStub, 'failingstub:run');
+      this.env.registerStub(this.PromiseFailingStub, 'promisefailingstub:run');
+      this.env.registerStub(this.EventFailingStub, 'eventfailingstub:run');
     });
 
     afterEach(function () {
@@ -256,8 +264,28 @@ describe('Environment', () => {
       this.env.run('some:unknown:generator');
     });
 
-    it('generator error calls callback properly', function (done) {
-      this.env.run('failingstub:run', err => {
+    it('generator promise error calls callback properly', function (done) {
+      this.env.run('promisefailingstub:run', err => {
+        assert.ok(this.runMethod.calledOnce);
+        assert.ok(err instanceof Error);
+        assert.equal(err.message, 'some error');
+        done();
+      });
+    });
+
+    it('generator error event calls callback properly', function (done) {
+      this.env.run('eventfailingstub:run', err => {
+        assert.ok(this.runMethod.calledOnce);
+        assert.ok(err instanceof Error);
+        assert.equal(err.message, 'some error');
+        done();
+      });
+    });
+
+    it('generator error event emits error event when no callback passed', function (done) {
+      const generator = this.env.run('eventfailingstub:run');
+      assert.equal(generator.listenerCount('error'), 0);
+      generator.on('error', err => {
         assert.ok(this.runMethod.calledOnce);
         assert.ok(err instanceof Error);
         assert.equal(err.message, 'some error');


### PR DESCRIPTION
Fix generator error handling (Fix #89)

When a generator's run emits an 'error' event, there is no handler for it, thus causing the application to crash.
In some cases the error is also passed to the callback of the run method, which can cause double handling of the error event.
The solution is to handle the event of the generator and call the callback with it, while ensuring the callback is only being called once.
If no callback was passed, keep backwards behavior and let the emitted error crash the application (as it is not handled). This is the expected behaviour when using the yo cli tool