### PR TITLE
Update resolver.js

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -42,7 +42,7 @@ resolver.lookup = function (cb) {
   }
 
   for (const pattern of patterns) {
-    for (const filename of globby.sync('*/index.js', {cwd: pattern, absolute: true})) {
+    for (const filename of globby.sync('*/index.js', {cwd: pattern, absolute: true, deep: 1})) {
       this._tryRegistering(filename);
     }
   }
@@ -73,8 +73,11 @@ resolver.findGeneratorsIn = function (searchPaths) {
     // restricted folders.
     try {
       modules = modules.concat(globby.sync(
-        ['generator-*', '@*/generator-*'],
-        {cwd: root, onlyFiles: false, absolute: true}
+        ['generator-*'],
+        {cwd: root, onlyFiles: false, absolute: true, deep: 0}
+      ), globby.sync(
+        ['@*/generator-*'],
+        {cwd: root, onlyFiles: false, absolute: true, deep: 1}
       ));
     } catch (err) {
       debug('Could not access %s (%s)', root, err);


### PR DESCRIPTION
Limit depth of globby.sync calls to increase speed while searching for generators.