### PR TITLE
Ensure that the namespace and resolved properties are passed

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -376,6 +376,8 @@ class Environment extends EventEmitter {
     const Generator = this.get(namespace);
 
     if (typeof Generator !== 'undefined' && typeof Generator.default === 'function') {
+      Generator.default.resolved = Generator.resolved;
+      Generator.default.namespace = Generator.namespace;
       return this.instantiate(Generator.default, options);
     }
 

--- a/test/environment.js
+++ b/test/environment.js
@@ -162,6 +162,18 @@ describe('Environment', () => {
     it('adds the namespace as called on the options', function () {
       assert.equal(this.env.create('stub:foo:bar').options.namespace, 'stub:foo:bar');
     });
+
+    it('adds the namespace from a module generator on the options', function () {
+      this.env
+        .register(path.join(__dirname, './fixtures/generator-module/generators/app'), 'fixtures:generator-module');
+      assert.equal(this.env.create('fixtures:generator-module').options.namespace, 'fixtures:generator-module');
+    });
+
+    it('adds the Generator resolved path from a module generator on the options', function () {
+      this.env
+        .register(path.join(__dirname, './fixtures/generator-module/generators/app'), 'fixtures:generator-module');
+      assert.equal(this.env.create('fixtures:generator-module').options.resolved, this.env.get('fixtures:generator-module').resolved);
+    });
   });
 
   describe('#run()', () => {


### PR DESCRIPTION
In the case of a module generator, the namespace and resolved properties
were being lost as the instantiate function expects them to be attached
as properties of the constructor function. This commit ensures they
are being passed where the instantiate function expects to find them.

For issue #107