### PR TITLE
Add localOnly argument to generator lookup

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -33,12 +33,10 @@ const resolver = module.exports;
  * @param {function} cb - Callback called once the lookup is done. Take err as first
  *                        parameter.
  */
-resolver.lookup = function (localOnly, cb) {
+resolver.lookup = function (localOnly = false, cb) {
   // Resolve signature where localOnly is omitted.
-  if (typeof localOnly !== 'boolean') {
-    if (typeof localOnly === 'function') {
-      cb = localOnly;
-    }
+  if (typeof localOnly === 'function') {
+    cb = localOnly;
     localOnly = false;
   }
 

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -28,11 +28,21 @@ const resolver = module.exports;
  * So this index file `node_modules/generator-dummy/lib/generators/yo/index.js` would be
  * registered as `dummy:yo` generator.
  *
+ * @param {boolean} [localOnly = false] - Set trueto skip lookups of
+ *                                        globally-installed generators.
  * @param {function} cb - Callback called once the lookup is done. Take err as first
  *                        parameter.
  */
-resolver.lookup = function (cb) {
-  const generatorsModules = this.findGeneratorsIn(this.getNpmPaths().reverse());
+resolver.lookup = function (localOnly, cb) {
+  // Resolve signature where localOnly is omitted.
+  if (typeof localOnly !== 'boolean') {
+    if (typeof localOnly === 'function') {
+      cb = localOnly;
+    }
+    localOnly = false;
+  }
+
+  const generatorsModules = this.findGeneratorsIn(this.getNpmPaths(localOnly).reverse());
   const patterns = [];
 
   for (const lookup of this.lookups) {
@@ -123,9 +133,50 @@ resolver._tryRegistering = function (generatorReference) {
 
 /**
  * Get the npm lookup directories (`node_modules/`)
+ * @param {boolean} [localOnly = false] - Set true to exclude global lookup
+ *                                        directories.
  * @return {Array} lookup paths
  */
-resolver.getNpmPaths = function () {
+resolver.getNpmPaths = function (localOnly = false) {
+  // Start with the local paths.
+  let paths = this._getLocalNpmPaths();
+
+  // Append global paths, unless they should be excluded.
+  if (!localOnly) {
+    paths = paths.concat(this._getGlobalNpmPaths());
+  }
+
+  return _.uniq(paths);
+};
+
+/**
+ * Get the local npm lookup directories
+ * @private
+ * @return {Array} lookup paths
+ */
+resolver._getLocalNpmPaths = function () {
+  const paths = [];
+
+  // Walk up the CWD and add `node_modules/` folder lookup on each level
+  process.cwd().split(path.sep).forEach((part, i, parts) => {
+    let lookup = path.join(...parts.slice(0, i + 1), 'node_modules');
+
+    if (!win32) {
+      lookup = `/${lookup}`;
+    }
+
+    paths.push(lookup);
+  });
+
+  return _.uniq(paths.reverse());
+};
+
+/**
+ * Get the global npm lookup directories
+ * @private
+ * @return {Array} lookup paths
+ */
+resolver._getGlobalNpmPaths = function () {
   let paths = [];
 
   // Default paths for each system
@@ -174,17 +225,6 @@ resolver.getNpmPaths = function () {
   if (process.argv[1]) {
     paths.push(path.join(path.dirname(process.argv[1]), '../..'));
   }
-
-  // Walk up the CWD and add `node_modules/` folder lookup on each level
-  process.cwd().split(path.sep).forEach((part, i, parts) => {
-    let lookup = path.join(...parts.slice(0, i + 1), 'node_modules');
-
-    if (!win32) {
-      lookup = `/${lookup}`;
-    }
-
-    paths.push(lookup);
-  });
 
   return _.uniq(paths.reverse());
 };

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -233,7 +233,7 @@ describe('Environment Resolver', function () {
       });
     });
 
-    describe('when localsOnly argument is true', () => {
+    describe('when localOnly argument is true', () => {
       afterEach(() => {
         delete process.env.NODE_PATH;
         delete process.env.NVM_PATH;

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -106,6 +106,36 @@ describe('Environment Resolver', function () {
         assert.ok(resolved.indexOf('subdir') !== -1, `Couldn't find 'subdir' in ${resolved}`);
       });
     });
+
+    describe('when localOnly argument is true', () => {
+      beforeEach(function () {
+        this.env = new Environment();
+        assert.equal(this.env.namespaces().length, 0, 'ensure env is empty');
+        this.env.lookup(true);
+      });
+
+      it('register local generators', function () {
+        assert.ok(this.env.get('dummy:app'));
+        assert.ok(this.env.get('dummy:yo'));
+      });
+
+      it('register generators in scoped packages', function () {
+        assert.ok(this.env.get('@dummyscope/scoped:app'));
+      });
+
+      it('register non-dependency local generator', function () {
+        assert.ok(this.env.get('jquery:app'));
+      });
+
+      it('register symlinked generators', function () {
+        assert.ok(this.env.get('extend:support'));
+      });
+
+      globalLookupTest('does not register global generators', function () {
+        assert.ok(!this.env.get('dummytest:app'));
+        assert.ok(!this.env.get('dummytest:controller'));
+      });
+    });
   });
 
   describe('#getNpmPaths()', () => {
@@ -200,6 +230,41 @@ describe('Environment Resolver', function () {
       it('append best bet if NVM_PATH is unset', function () {
         assert(this.env.getNpmPaths().indexOf(path.join(this.bestBet, 'node_modules')) >= 0);
         assert(this.env.getNpmPaths().indexOf(this.bestBet2) >= 0);
+      });
+    });
+
+    describe('when localsOnly argument is true', () => {
+      afterEach(() => {
+        delete process.env.NODE_PATH;
+        delete process.env.NVM_PATH;
+      });
+
+      it('walk up the CWD lookups dir', function () {
+        const paths = this.env.getNpmPaths();
+        assert.equal(paths[0], path.join(process.cwd(), 'node_modules'));
+        assert.equal(paths[1], path.join(process.cwd(), '../node_modules'));
+      });
+
+      it('does not append NODE_PATH', function () {
+        process.env.NODE_PATH = '/some/dummy/path';
+        assert(this.env.getNpmPaths(true).indexOf(process.env.NODE_PATH) === -1);
+      });
+
+      it('does not append NVM_PATH', function () {
+        process.env.NVM_PATH = '/some/dummy/path';
+        assert(this.env.getNpmPaths(true).indexOf(path.join(path.dirname(process.env.NVM_PATH), 'node_modules')) === -1);
+      });
+
+      it('does not append best bet', function () {
+        assert(this.env.getNpmPaths(true).indexOf(this.bestBet) === -1);
+      });
+
+      it('does not append default NPM dir depending on your OS', function () {
+        if (process.platform === 'win32') {
+          assert(this.env.getNpmPaths(true).indexOf(path.join(process.env.APPDATA, 'npm/node_modules')) === -1);
+        } else {
+          assert(this.env.getNpmPaths(true).indexOf('/usr/lib/node_modules') === -1);
+        }
       });
     });
   });


### PR DESCRIPTION
I've noticed that, when building a list of generators, `yo` will list any globally-installed generators, in addition to any it can find in local `node_modules` directories. I understand why it does this, of course, but there are situations where I'd like to change this behavior and only display local generators, and I'm sure I"m probably not alone in this.

For my particular use case, I'm creating NPM package projects, each with a script that runs *yo* to pick from a list of generators that developers can use to quickly add files for new classes, tests, and so on.

As any veteran NPM user can attest, installing both `yo` and the project-specific generators *locally* is far more ideal than trying to have all of these projects share the same copies of these dependencies as globally-installed modules. The former approach allows me to make breaking changes to generated code, and update the dependencies in each project as time and project-specific needs permit. The latter approach? Not so much.

Fortunately the former approach is relatively easy to accomplish. All I have to do is install `yo` and whatever generators I need as devDependencies in each project. Npm scripts will use this locally-installed `yo`, as it will with any other locally-installed CLI.

However, *if* the user is using yeoman for anything else, chances are they'll have some globally-installed generators as well, and these will show up in the generator list, even when running the locally-installed `yo`. This creates potential for a lot of clutter and confusion that I'd prefer to avoid.

What I'd like to do is add a `--local-only` flag to `yo` for this purpose. To make that happen I'll first need to make some changes to `yeoman-environment`. In this PR I've added a `localOnly` argument to a couple of the `resolver` methods that need it. This changes the signature of the `#lookup` method, but does so in a way that is backwards compatible with the old signature.

I also have changes ready for `yo` itself to add the flag and pass it through to this new argument, but I'll hold off on making the PR for that for now. If and when this `environment` change is published I'll gladly contribute that as well.

Thanks!