### PR TITLE
Implement integrating and transforming queues and update enforceUpdate.

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -5,6 +5,7 @@ const EventEmitter = require('events');
 const chalk = require('chalk');
 const _ = require('lodash');
 const GroupedQueue = require('grouped-queue');
+const SubQueue = require('grouped-queue/lib/subqueue');
 const escapeStrRe = require('escape-string-regexp');
 const untildify = require('untildify');
 const memFs = require('mem-fs');
@@ -92,6 +93,8 @@ class Environment extends EventEmitter {
       'configuring',
       'default',
       'writing',
+      'integrating',
+      'transforming',
       'conflicts',
       'install',
       'end'
@@ -114,16 +117,48 @@ class Environment extends EventEmitter {
     }
 
     if (!env.runLoop) {
-      env.runLoop = new GroupedQueue([
-        'initializing',
-        'prompting',
-        'configuring',
-        'default',
-        'writing',
-        'conflicts',
-        'install',
-        'end'
-      ]);
+      env.runLoop = new GroupedQueue(Environment.queues);
+    }
+
+    const runLoop = env.runLoop;
+    if (!runLoop.queueNames.includes('integrating')) {
+      if (!runLoop.addSubQueue) {
+        // Implement addSubQueue for grouped-queue <= 3.3.0
+        runLoop.addSubQueue = function (name, before) {
+          if (this.__queues__[name]) {
+            // Sub-queue already exists
+            return;
+          }
+
+          if (!before) {
+            // Add at last place.
+            this.__queues__[name] = new SubQueue();
+            this.queueNames.push(name);
+            return;
+          }
+
+          if (!this.__queues__[before] || _.indexOf(this.queueNames, before) === -1) {
+            throw new Error('sub-queue ' + before + ' not found');
+          }
+
+          const current = this.__queues__;
+          const currentNames = Object.keys(current);
+          // Recreate the queue with new order.
+          this.__queues__ = {};
+          currentNames.forEach(currentName => {
+            if (currentName === before) {
+              this.__queues__[name] = new SubQueue();
+            }
+            this.__queues__[currentName] = current[currentName];
+          });
+
+          // Recreate queueNames
+          this.queueNames = Object.keys(this.__queues__);
+        };
+      }
+
+      runLoop.addSubQueue('integrating', 'conflicts');
+      runLoop.addSubQueue('transforming', 'conflicts');
     }
 
     if (!env.sharedFs) {


### PR DESCRIPTION
- integrating step should be used to customize files, like change a file
from another generator
- transforming should be useful cleanup files (stubs for customization)
and for creating generic lint and prettier only generators.