### PR TITLE
Enable filterPaths option by default.

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -136,7 +136,7 @@ resolver._tryRegistering = function (generatorReference, packagePath) {
  * @param {boolean|Object} [options]
  * @param {boolean} [options.localOnly = false] - Set true to skip lookups of
  *                                               globally-installed generators.
- * @param {boolean} [options.filterPaths = false] - Remove paths that don't ends
+ * @param {boolean} [options.filterPaths = true] - Remove paths that don't ends
  *                       with a supported path (don't touch at NODE_PATH paths).
  * @return {Array} lookup paths
  */
@@ -145,12 +145,15 @@ resolver.getNpmPaths = function (options = {}) {
   if (typeof options === 'boolean') {
     options = {localOnly: options};
   }
+  // Enable filterPaths by default.
+  const filterPaths = options.filterPaths === undefined ? true : options.filterPaths;
+
   // Start with the local paths.
   let paths = this._getLocalNpmPaths();
 
   // Append global paths, unless they should be excluded.
   if (!options.localOnly) {
-    paths = paths.concat(this._getGlobalNpmPaths(options.filterPaths));
+    paths = paths.concat(this._getGlobalNpmPaths(filterPaths));
   }
 
   return _.uniq(paths);

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -220,8 +220,10 @@ describe('Environment Resolver', function () {
       });
 
       it('append best bet if NODE_PATH is unset', function () {
-        assert(this.env.getNpmPaths().indexOf(this.bestBet) >= 0);
+        assert(this.env.getNpmPaths({filterPaths: false}).indexOf(this.bestBet) >= 0);
+        assert(this.env.getNpmPaths().indexOf(this.bestBet) === -1);
         assert(this.env.getNpmPaths().indexOf(this.bestBet2) >= 0);
+        assert(this.bestBet2.endsWith('node_modules'));
       });
 
       it('append default NPM dir depending on your OS', function () {
@@ -267,6 +269,7 @@ describe('Environment Resolver', function () {
       it('append best bet if NVM_PATH is unset', function () {
         assert(this.env.getNpmPaths().indexOf(path.join(this.bestBet, 'node_modules')) >= 0);
         assert(this.env.getNpmPaths().indexOf(this.bestBet2) >= 0);
+        assert(this.bestBet2.endsWith('node_modules'));
       });
     });
 
@@ -293,7 +296,8 @@ describe('Environment Resolver', function () {
       });
 
       it('does not append best bet', function () {
-        assert(this.env.getNpmPaths(true).indexOf(this.bestBet) === -1);
+        assert(this.env.getNpmPaths({localOnly: true, filterPaths: false}).indexOf(this.bestBet) === -1);
+        assert(this.env.getNpmPaths({localOnly: false, filterPaths: true}).indexOf(this.bestBet) === -1);
       });
 
       it('does not append default NPM dir depending on your OS', function () {


### PR DESCRIPTION
This is a breaking change, I think it should go to environment 3.0.0

Look for parent generators only when dir is a repository ('node_modules').

When running the generator inside dir /home/user/git/my_project.
environment 2.7.0 will look for generators at /home/user/git/generator-* ,
/home/user/generator-* , /home/generator-* and /generator-*.

This commit changes the behavior to only look for generator at parent
dirs if they are called 'node_modules'.
Ex: Running inside '/home/user/git/my_project/node_modules/subproject',
then the environment will look for generators at
/home/user/git/my_project/node_modules/generator-* , but not
/home/user/git/my_project/generator-* .