### PR TITLE
Change findGeneratorsIn to add root folder if it's a valid generator.

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -82,6 +82,11 @@ resolver.findGeneratorsIn = function (searchPaths, pattern = 'generator-*') {
     // catch to handle the error gracefully as globby doesn't have an option to skip
     // restricted folders.
     try {
+      // Root is a valid generator, add it
+      if (/generator-.*/.test(path.basename(root))) {
+        modules.push(root);
+      }
+
       modules = modules.concat(globby.sync(
         pattern,
         {cwd: root, onlyFiles: false, absolute: true, deep: 0}

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -319,6 +319,26 @@ describe('Environment Resolver', function () {
     });
   });
 
+  describe('#findGeneratorsIn()', () => {
+    beforeEach(function () {
+      this.env = new Environment();
+    });
+
+    describe('when root path is a valid generator', () => {
+      it('pass through root directory', function () {
+        const dummyGenerator = 'generator-dummy';
+        assert(this.env.findGeneratorsIn([dummyGenerator])[0].endsWith(dummyGenerator));
+      });
+    });
+
+    describe('when root path is not a valid generator', () => {
+      it('pass through root directory', function () {
+        const dummyGenerator = 'generator123-dummy';
+        assert(this.env.findGeneratorsIn([dummyGenerator]).length === 0);
+      });
+    });
+  });
+
   describe('#lookupGenerator()', () => {
     const scopedFolder = path.resolve('node_modules/@dummyscope');
     const scopedGenerator = path.join(scopedFolder, 'generator-scoped');


### PR DESCRIPTION
Environment#lookup() now allows to lookup generators from a single
package:
Ex: Environment#lookup({npmPaths: ['.../node_modules/generator-foo']);