### PR TITLE
Use _callbackWrapper to catch generator promise error.

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -486,11 +486,9 @@ class Environment extends EventEmitter {
    * An error is raised on invalid namespace.
    *
    * @param {String} namespace
-   * @param {Object} options
+   * @param {Object} [options]
    */
-  create(namespace, options) {
-    options = options || {};
-
+  create(namespace, options = this.options) {
     const Generator = this.get(namespace);
 
     if (typeof Generator !== 'undefined' && typeof Generator.default === 'function') {

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -592,12 +592,17 @@ class Environment extends EventEmitter {
    * See https://github.com/yeoman/environment/pull/101
    *
    * @param {Object}       generator
-   * @param {Function}     done
+   * @param {Function}     [done]
    */
   runGenerator(generator, done) {
     const _callbackWrapper = callbackWrapper(generator, done);
 
-    return generator.run(_callbackWrapper);
+    const run = generator.run(_callbackWrapper);
+    // Generator started returning promise on 3.x
+    if (done && run instanceof Promise) {
+      run.catch(_callbackWrapper);
+    }
+    return run;
   }
 
   /**


### PR DESCRIPTION
Currently _callbackWrapper is used to listen error event and generator callback.
Use it for catching generator promise too.