### PR TITLE
Catch generator's instantiation errors.

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -516,7 +516,11 @@ class Environment extends EventEmitter {
       );
     }
 
-    return this.instantiate(Generator, options);
+    try {
+      return this.instantiate(Generator, options);
+    } catch (err) {
+      return this.error(err);
+    }
   }
 
   /**


### PR DESCRIPTION
When a generator fails to instantiate we probably should catch and behave like not found error.