### PR TITLE
Revert yeoman-environment behaviour.

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -242,13 +242,16 @@ class Environment extends EventEmitter {
 
     // Used sharedOptions from options if exists.
     this.sharedOptions = this.options.sharedOptions || {};
-    // Create a default sharedData.
-    this.sharedOptions.sharedData = this.sharedOptions.sharedData || {};
-    // Pass forwardErrorToEnvironment=true to generators by default.
-    this.sharedOptions.forwardErrorToEnvironment =
-      this.sharedOptions.forwardErrorToEnvironment === undefined ? true : this.sharedOptions.forwardErrorToEnvironment;
     // Remove Unecessary sharedOptions from options
     delete this.options.sharedOptions;
+
+    // Create a default sharedData.
+    this.sharedOptions.sharedData = this.sharedOptions.sharedData || {};
+
+    const {newErrorHandler = false} = this.options;
+    // Pass forwardErrorToEnvironment to generators.
+    this.sharedOptions.forwardErrorToEnvironment =
+      this.sharedOptions.forwardErrorToEnvironment === undefined ? newErrorHandler : this.sharedOptions.forwardErrorToEnvironment;
 
     this.repository = Object.assign({}, repository);
     if (this.options.yeomanRepository) {
@@ -743,12 +746,26 @@ class Environment extends EventEmitter {
    * @param {Function}     [done]
    */
   runGenerator(generator, done) {
+    const {newErrorHandler} = this.options;
     const promise = new Promise((resolve, reject) => {
-      // Listen to errors and reject if emmited.
-      this.on('error', error => {
-        // Make sure runLoop is stopped.
-        this.runLoop.pause();
-        reject(error);
+      // Old behavior throws an exception directly to node.js due to scheduled throw.
+      // https://nodejs.org/api/events.html#events_error_events
+      if (newErrorHandler) {
+        // Listen to errors and reject if emmited.
+        this.on('error', error => {
+          // Make sure runLoop is stopped.
+          this.runLoop.pause();
+          reject(error);
+        });
+      }
+
+      // Root generator always forwarded to reject.
+      generator.on('error', reject);
+
+      // If runLoop has ended, the environment has ended too.
+      this.runLoop.on('end', () => {
+        resolve();
+        this.emit('end');
       });
 
       /*
@@ -756,13 +773,12 @@ class Environment extends EventEmitter {
        * On reject cb(err) is called.
        * yeoman-generator 2.0.5 returns self.
        * yeoman-generator > 3.0.0 returns a Promise.
-       * Returned promise does't rejects on 'error' event, so listen to it.
+       * Returned promise doesn't rejects on 'error' event, so listen to it.
        */
       const generatorCallback = err => {
-        return err === undefined ? resolve(err) : reject(err);
+        return err === undefined ? resolve() : reject(err);
       };
-      this.runLoop.on('end', resolve);
-      generator.on('error', reject);
+
       const genPromise = generator.run(generatorCallback);
       if (genPromise instanceof Promise) {
         genPromise.then(resolve, reject);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3049,9 +3049,9 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "grouped-queue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-1.0.0.tgz",
-      "integrity": "sha512-XslfWrAGCYovQjveHODR0hllUrsn3UtvPFTkamHbgVHmkUA6eCIDmw3JDWVLJvuntTvYjwaPGamlyzK4/HAEOA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-1.1.0.tgz",
+      "integrity": "sha512-rZOFKfCqLhsu5VqjBjEWiwrYqJR07KxIkH4mLZlNlGDfntbb4FbMyGFP14TlvRPrU9S3Hnn/sgxbC5ZeN0no3Q==",
       "requires": {
         "lodash": "^4.17.15"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "escape-string-regexp": "^1.0.2",
     "execa": "^4.0.0",
     "globby": "^8.0.1",
-    "grouped-queue": "^1.0.0",
+    "grouped-queue": "^1.1.0",
     "inquirer": "^7.1.0",
     "is-scoped": "^1.0.0",
     "lodash": "^4.17.10",


### PR DESCRIPTION
When a generator fails, an error event is emitted on a scheduled task, and due to https://nodejs.org/api/events.html#events_error_events, an error will be thrown on a composed generator (no error event listener is registered).
The error will be treated directly by node.js killing the process.

This reverts the old behaviour where no error event listener is registered.