### PR TITLE
Use relative path to calculate namespace.

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -78,7 +78,12 @@ resolver.lookup = function (options = {localOnly: false}, cb = undefined) {
   this.packageLookup.sync(options, module => {
     const generatorPath = module.filePath;
     const packagePath = module.packagePath;
-    const namespace = this.namespace(generatorPath);
+    let repositoryPath = path.join(packagePath, '..');
+    if (path.basename(repositoryPath).startsWith('@')) {
+      // Scoped package
+      repositoryPath = path.join(repositoryPath, '..');
+    }
+    const namespace = this.namespace(path.relative(repositoryPath, generatorPath), lookups);
     const registered = this._tryRegistering(generatorPath, packagePath, namespace);
     generators.push({generatorPath, packagePath, namespace, registered});
     return options.singleResult && registered;


### PR DESCRIPTION
Fixes lookup outside node_modules repository.