### PR TITLE
Add "dist/generators" in lookups

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -70,7 +70,7 @@ class Environment extends EventEmitter {
   }
 
   static get lookups() {
-    return ['.', 'generators', 'lib/generators'];
+    return ['.', 'generators', 'lib/generators', 'dist/generators'];
   }
 
   /**


### PR DESCRIPTION
So typical TypeScript projects using `src`/`dist` folders work out of the box... :)
