### PR TITLE
Conflicter improvements

### DIFF
--- a/lib/util/conflicter.js
+++ b/lib/util/conflicter.js
@@ -46,9 +46,8 @@ class Conflicter {
     this.diffOptions = options.diffOptions;
 
     if (this.bail) {
-      // Set ignoreWhitespace as true by default for bail.
-      // Probably just testing, so don't override.
-      this.ignoreWhitespace = true;
+      // Bail conflicts with force option, if bail set force to false.
+      this.force = false;
     }
 
     this.queue = new GroupedQueue(['log', 'conflicts'], false);
@@ -188,7 +187,7 @@ class Conflicter {
     if (!fs.existsSync(file.path)) {
       if (this.bail) {
         this._log('writeln', 'Aborting ...');
-        return Promise.reject(ConflicterConflictError.create('Process aborted by conflict'));
+        return Promise.reject(ConflicterConflictError.create(`Process aborted by conflict: ${rfilepath}`));
       }
 
       this._log('create', rfilepath);
@@ -208,7 +207,9 @@ class Conflicter {
         this.adapter.log.conflict(rfilepath);
         this._printDiff(file);
         this.adapter.log.writeln('Aborting ...');
-        return Promise.reject(ConflicterConflictError.create('Process aborted by conflict'));
+        const error = ConflicterConflictError.create(`Process aborted by conflict: ${rfilepath}`);
+        error.file = file;
+        return Promise.reject(error);
       }
 
       if (this.dryRun) {

--- a/test/conflicter.js
+++ b/test/conflicter.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
 const sinon = require('sinon');
+const slash = require('slash');
+const semver = require('semver');
 const {TestAdapter} = require('yeoman-test/lib/adapter');
 const Conflicter = require('../lib/util/conflicter');
 
@@ -95,47 +97,65 @@ describe('Conflicter', () => {
       });
     });
 
-    it('abort on first conflict', function () {
-      this.timeout(4000);
-      const conflicter = new Conflicter(new TestAdapter(), {force: false, bail: true});
-      return conflicter.checkForCollision(this.conflictingFile).then(
-        () => assert.fail('was not supposed to succeed')
-      ).catch(error => {
-        assert.equal(error.message, 'Process aborted by conflict');
+    describe('with bail option', () => {
+      it('abort on first conflict', function () {
+        this.timeout(4000);
+        const conflicter = new Conflicter(new TestAdapter(), {bail: true});
+        return conflicter.checkForCollision(this.conflictingFile).then(
+          () => assert.fail('was not supposed to succeed')
+        ).catch(error => {
+          assert.equal(slash(error.message), 'Process aborted by conflict: test/conflicter.js');
+        });
       });
-    });
 
-    it('abort on first conflict with whitespace changes', () => {
-      const conflicter = new Conflicter(new TestAdapter(), {
-        force: false,
-        bail: true
-      });
-      return conflicter.checkForCollision(
-        {
-          path: path.join(__dirname, 'fixtures/conflicter/file-conflict.txt'),
-          contents: `initial
+      it('abort on first conflict with whitespace changes', function () {
+        if (!semver.satisfies(require('../node_modules/yeoman-generator/package.json').version, '>=5.0.0-beta.1')) {
+          this.skip();
+        }
+        const conflicter = new Conflicter(new TestAdapter(), {bail: true});
+        return conflicter.checkForCollision(
+          {
+            path: path.join(__dirname, 'fixtures/conflicter/file-conflict.txt'),
+            contents: `initial
                  content
       `
-        }
-      ).then(
-        file => {
-          assert.equal(file.conflicter, 'skip');
-        }
-      );
-    });
-
-    it('abort on create new file', () => {
-      const conflicter = new Conflicter(new TestAdapter(), {
-        force: false,
-        bail: true
+          }
+        )
+          .then(
+            () => assert.fail('was not supposed to succeed')
+          ).catch(error => {
+            assert.equal(slash(error.message), 'Process aborted by conflict: test/fixtures/conflicter/file-conflict.txt');
+          });
       });
-      return conflicter.checkForCollision({
-        path: 'file-who-does-not-exist2.js',
-        contents: ''
-      }).then(
-        () => assert.fail('was not supposed to succeed')
-      ).catch(error => {
-        assert.equal(error.message, 'Process aborted by conflict');
+
+      describe('with ignoreWhitespace option', () => {
+        it('should not abort on first conflict with whitespace changes', () => {
+          const conflicter = new Conflicter(new TestAdapter(), {ignoreWhitespace: true, bail: true});
+          return conflicter.checkForCollision(
+            {
+              path: path.join(__dirname, 'fixtures/conflicter/file-conflict.txt'),
+              contents: `initial
+                 content
+      `
+            }
+          ).then(
+            file => {
+              assert.equal(file.conflicter, 'skip');
+            }
+          );
+        });
+      });
+
+      it('abort on create new file', () => {
+        const conflicter = new Conflicter(new TestAdapter(), {bail: true});
+        return conflicter.checkForCollision({
+          path: 'file-who-does-not-exist2.js',
+          contents: ''
+        }).then(
+          () => assert.fail('was not supposed to succeed')
+        ).catch(error => {
+          assert.equal(error.message, 'Process aborted by conflict: file-who-does-not-exist2.js');
+        });
       });
     });
 


### PR DESCRIPTION
- bail requires `force=false`.
- should not force ignoreWhitespace.
- print conflicted file at error.