### PR TITLE
fix: error message when generator not found

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -750,7 +750,7 @@ class Environment extends Base {
           'You can see available generators via ' +
           chalk.yellow('npm search yeoman-generator') + ' or via ' + chalk.yellow('http://yeoman.io/generators/') + '. \n' +
           'Install them with ' + chalk.yellow(`npm install ${generatorHint}`) + '.\n\n' +
-          'To see all your installed generators run ' + chalk.yellow('yo') + ' without any arguments. ' +
+          'To see all your installed generators run ' + chalk.yellow('yo --generators') + '. ' +
           'Adding the ' + chalk.yellow('--help') + ' option will also show subgenerators. \n\n' +
           'If ' + chalk.yellow('yo') + ' cannot find the generator, run ' + chalk.yellow('yo doctor') + ' to troubleshoot your system.'
         );


### PR DESCRIPTION
Error message when generator was not found hinted invalid command: `yo` to list all generators.
With [yo](https://github.com/yeoman/yo) v2 or newer the command should be: `yo --generators. See [yo/lib/usage](https://github.com/yeoman/yo/blob/ea5e36b44af14e6930b4b8c436665533e094fe3c/lib/usage.txt#L9).