### PR TITLE
Fix typo in file transform

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -1206,7 +1206,7 @@ class Environment extends Base {
   applyTransforms(transformStreams, options = {}) {
     const {
       stream = this.sharedFs.stream(),
-      name = 'Tranforming'
+      name = 'Transforming'
     } = options;
 
     let {log = true} = options;


### PR DESCRIPTION
Fix typo in progress indicator for transforms.

![image](https://user-images.githubusercontent.com/1439341/182791131-b2922b2a-dc8a-4dcc-80db-117b94a9c2f8.png)
