### PR TITLE
fix: explicitly define and export Package subpath './lib/util/namespace'

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "./cli/*": "./cli/*.js",
     "./lib/*": "./lib/*.js",
     "./lib/util/*": "./lib/util/*.js",
+    "./lib/util/namespace": "./lib/util/namespace.js",
     "./adapter": "./lib/adapter.js",
     "./conflicter": "./lib/util/conflicter.js",
     "./log": "./lib/util/log.js",


### PR DESCRIPTION
On Node 18, "yeoman-environment" package is creating issue due to missing package path export.

Fix https://github.com/jhipster/generator-jhipster/issues/20349

Fix https://github.com/jhipster/generator-jhipster/issues/19627

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>