### PR TITLE
Do not throw error for local path resolution

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,3 +1,4 @@
 module.exports = {
   parallel: true,
+  timeout: '30s',
 };

--- a/src/util/resolve.ts
+++ b/src/util/resolve.ts
@@ -14,8 +14,6 @@ export async function resolveModulePath(specifier: string, resolvedOrigin?: stri
   if (maybeResolved.startsWith('.')) {
     if (resolvedOrigin) {
       maybeResolved = resolve(dirname(resolvedOrigin), '..', maybeResolved);
-    } else {
-      throw new Error(`Specifier ${maybeResolved} could not be calculated`);
     }
   }
 

--- a/src/util/resolve.ts
+++ b/src/util/resolve.ts
@@ -11,10 +11,8 @@ import { defaultExtensions } from '../generator-lookup.js';
  */
 export async function resolveModulePath(specifier: string, resolvedOrigin?: string) {
   let maybeResolved = specifier;
-  if (maybeResolved.startsWith('.')) {
-    if (resolvedOrigin) {
-      maybeResolved = resolve(dirname(resolvedOrigin), '..', maybeResolved);
-    }
+  if (maybeResolved.startsWith('.') && resolvedOrigin) {
+    maybeResolved = resolve(dirname(resolvedOrigin), '..', maybeResolved);
   }
 
   maybeResolved = untildify(maybeResolved);


### PR DESCRIPTION
Fixes https://github.com/yeoman/environment/issues/497

When there is a local path for a generator, i.e. `./my-directory/my-generator`, the `yeoman-environment` cannot locate the generator and throws an error saying `You don't seem to have a generator with the name undefined installed`. I had mistakenly thought that this was because the generator needed to be loaded with `@yeoman/namespace`, but that's only for package lookups. Instead, the base environment's `create` function detects that the `namespaceOrPath` is a `string` and calls `get` on it, which in turn uses the `resolveModulePath` function to find the file.

However, the `resolveModulePath` function checks if there is a `.` character in the front of the path and then throws an error if there is not a `resolvedOrigin` passed into the function. In the case of these local paths, the `get` function does not pass the `resolvedOrigin` parameter, so it's `undefined`.

The fix here is just to remove the `else` block that is throwing the error - if there is a path with a `.` in front and no `resolvedOrigin`, just go ahead and do the lookups further in the function. When I made this change locally in my `node_modules` folder, it then allowed me to run a generator from a local path.