### PR TITLE
add callback function support for generator scheduling

### DIFF
--- a/src/environment-base.ts
+++ b/src/environment-base.ts
@@ -425,6 +425,7 @@ export default class EnvironmentBase extends EventEmitter implements BaseEnviron
     const { schedule = true, ...instantiateOptions } = options;
 
     const generatorInstance = await this.create(generator, instantiateOptions);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
     // @ts-ignore: keep type compatibility with old @yeoman/types
     return this.queueGenerator(generatorInstance, { schedule: typeof schedule === 'function' ? schedule(generatorInstance) : schedule });
   }

--- a/src/environment-base.ts
+++ b/src/environment-base.ts
@@ -425,6 +425,7 @@ export default class EnvironmentBase extends EventEmitter implements BaseEnviron
     const { schedule = true, ...instantiateOptions } = options;
 
     const generatorInstance = await this.create(generator, instantiateOptions);
+    // @ts-ignore: keep type compatibility with old @yeoman/types
     return this.queueGenerator(generatorInstance, { schedule: typeof schedule === 'function' ? schedule(generatorInstance) : schedule });
   }
 

--- a/src/environment-base.ts
+++ b/src/environment-base.ts
@@ -425,7 +425,7 @@ export default class EnvironmentBase extends EventEmitter implements BaseEnviron
     const { schedule = true, ...instantiateOptions } = options;
 
     const generatorInstance = await this.create(generator, instantiateOptions);
-    return this.queueGenerator(generatorInstance, { schedule });
+    return this.queueGenerator(generatorInstance, { schedule: typeof schedule === 'function' ? schedule(generatorInstance) : schedule });
   }
 
   /**

--- a/src/environment-base.ts
+++ b/src/environment-base.ts
@@ -425,7 +425,7 @@ export default class EnvironmentBase extends EventEmitter implements BaseEnviron
     const { schedule: passedSchedule = true, ...instantiateOptions } = options;
 
     const generatorInstance = await this.create(generator, instantiateOptions);
-    // Keep type compatibility with old @yeoman/types
+    // Convert to function to keep type compatibility with old @yeoman/types where schedule is boolean only
     const schedule: (gen: G) => boolean = typeof passedSchedule === 'function' ? passedSchedule : () => passedSchedule;
     return this.queueGenerator(generatorInstance, { schedule: schedule(generatorInstance) });
   }

--- a/src/environment-base.ts
+++ b/src/environment-base.ts
@@ -426,7 +426,7 @@ export default class EnvironmentBase extends EventEmitter implements BaseEnviron
 
     const generatorInstance = await this.create(generator, instantiateOptions);
     // Keep type compatibility with old @yeoman/types
-    const schedule: (G) => boolean = typeof schedule === 'function' ? schedule : () => schedule;
+    const schedule: (G) => boolean = typeof passedSchedule === 'function' ? passedSchedule : () => passedSchedule;
     return this.queueGenerator(generatorInstance, { schedule: schedule(generatorInstance) });
   }
 

--- a/src/environment-base.ts
+++ b/src/environment-base.ts
@@ -426,7 +426,7 @@ export default class EnvironmentBase extends EventEmitter implements BaseEnviron
 
     const generatorInstance = await this.create(generator, instantiateOptions);
     // Keep type compatibility with old @yeoman/types
-    const schedule: (G) => boolean = typeof passedSchedule === 'function' ? passedSchedule : () => passedSchedule;
+    const schedule: (gen: G) => boolean = typeof passedSchedule === 'function' ? passedSchedule : () => passedSchedule;
     return this.queueGenerator(generatorInstance, { schedule: schedule(generatorInstance) });
   }
 

--- a/src/environment-base.ts
+++ b/src/environment-base.ts
@@ -422,12 +422,12 @@ export default class EnvironmentBase extends EventEmitter implements BaseEnviron
   ): Promise<G>;
   async composeWith<G extends BaseGenerator = BaseGenerator>(generator: string | GetGeneratorConstructor<G>, ...args: any[]): Promise<G> {
     const options = getComposeOptions(...args) as ComposeOptions<G>;
-    const { schedule = true, ...instantiateOptions } = options;
+    const { schedule = true: passedSchedule, ...instantiateOptions } = options;
 
     const generatorInstance = await this.create(generator, instantiateOptions);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-    // @ts-ignore: keep type compatibility with old @yeoman/types
-    return this.queueGenerator(generatorInstance, { schedule: typeof schedule === 'function' ? schedule(generatorInstance) : schedule });
+    // Keep type compatibility with old @yeoman/types
+    const schedule: (G) => boolean = typeof schedule === 'function' ? schedule : () => schedule;
+    return this.queueGenerator(generatorInstance, { schedule: schedule(generatorInstance) });
   }
 
   /**

--- a/src/environment-base.ts
+++ b/src/environment-base.ts
@@ -422,7 +422,7 @@ export default class EnvironmentBase extends EventEmitter implements BaseEnviron
   ): Promise<G>;
   async composeWith<G extends BaseGenerator = BaseGenerator>(generator: string | GetGeneratorConstructor<G>, ...args: any[]): Promise<G> {
     const options = getComposeOptions(...args) as ComposeOptions<G>;
-    const { schedule = true: passedSchedule, ...instantiateOptions } = options;
+    const { schedule: passedSchedule = true, ...instantiateOptions } = options;
 
     const generatorInstance = await this.create(generator, instantiateOptions);
     // Keep type compatibility with old @yeoman/types

--- a/test/environment.js
+++ b/test/environment.js
@@ -272,6 +272,18 @@ for (const generatorVersion of allVersions) {
           }
         });
       });
+      describe('passing function schedule parameter', () => {
+        it('returning false should not schedule generator', async function () {
+          this.env.queueTask = sinon.spy();
+          await this.env.composeWith('stub', { generatorArgs: [], schedule: () => false });
+          if (isGreaterThan6(generatorVersion)) {
+            assert(this.env.queueTask.calledOnce);
+            assert(this.env.queueTask.getCall(0).firstArg !== 'environment:run');
+          } else {
+            assert(this.env.queueTask.notCalled);
+          }
+        });
+      });
 
       it('should emit a compose event', function (done) {
         this.env.once('compose', (namespace, generator) => {


### PR DESCRIPTION
depends on  yeoman/yeoman-api#6
required by  jhipster/generator-jhipster#25445

This PR allows a callback function as an option for `ComposeOptions.schedule`

The function receives the generator instance as the parameter and must return a boolean that will decide the scheduling. A true return value schedules the generator to be run under environment:run loop and a false queues the generator tasks immediately.

usage:
```
env.composeWith('hello:world', { schedule: (generator) => {
    // some code to decide the scheduling option
   return generator.immediate;
}});
```