### PR TITLE
add bun support as a package manager

### DIFF
--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -89,7 +89,7 @@ Changes to package.json were detected.`);
       adapter.log('Error detecting the package manager. Falling back to npm.');
     }
 
-    if (!['npm', 'yarn', 'pnpm'].includes(packageManagerName)) {
+    if (!['npm', 'yarn', 'pnpm', 'bun'].includes(packageManagerName)) {
       adapter.log(`${packageManagerName} is not a supported package manager. Run it by yourself.`);
       return false;
     }

--- a/test/package-manager.js
+++ b/test/package-manager.js
@@ -143,6 +143,24 @@ No change to package.json was detected. No package manager install will be execu
           });
         });
 
+        describe('with bun', () => {
+          beforeEach(async () => {
+            whichPackageManager.mockResolvedValue('bun');
+            await packageManagerInstallTask({ adapter, memFs, packageJsonLocation });
+          });
+
+          it('should log', async () => {
+            expect(adapter.log).toBeCalledTimes(2);
+            expect(adapter.log).toHaveBeenNthCalledWith(1, changesToPackageJson);
+            expect(adapter.log).toHaveBeenNthCalledWith(2, runningPackageManager('bun'));
+          });
+
+          it('should execute bun', () => {
+            expect(execa).toBeCalled();
+            expect(execa).toBeCalledWith('bun', ['install'], expect.any(Object));
+          });
+        });
+
         describe('with an unsupported package manager', () => {
           beforeEach(async () => {
             await packageManagerInstallTask({ adapter, memFs, packageJsonLocation, nodePackageManager: 'foo' });


### PR DESCRIPTION
[Bun](https://bun.sh/) is an all-in-one JavaScript runtime & toolkit designed for speed, complete with a bundler, test runner, and Node.js-compatible package manager. 