### PR TITLE
chore(deps): switch to tinyglobby

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "debug": "^4.4.0",
         "execa": "^9.5.3",
         "fly-import": "^0.4.1",
-        "globby": "^14.1.0",
         "grouped-queue": "^2.0.0",
         "locate-path": "^7.2.0",
         "lodash-es": "^4.17.21",
@@ -28,6 +27,7 @@
         "mem-fs-editor": "^11.1.4",
         "semver": "^7.7.2",
         "slash": "^5.1.0",
+        "tinyglobby": "^0.2.14",
         "untildify": "^5.0.0",
         "which-package-manager": "^1.0.1"
       },
@@ -7429,16 +7429,6 @@
         "url": "https://bevry.me/fund"
       }
     },
-    "node_modules/istextorbinary/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/istextorbinary/node_modules/textextensions": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.6.0.tgz",
@@ -10620,16 +10610,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/read-pkg-up/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/read-pkg-up/node_modules/type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -11887,10 +11867,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
-      "dev": true,
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.4.4",
@@ -11907,7 +11886,6 @@
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
       "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "picomatch": "^3 || ^4"
@@ -11922,7 +11900,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "debug": "^4.4.0",
     "execa": "^9.5.3",
     "fly-import": "^0.4.1",
-    "globby": "^14.1.0",
     "grouped-queue": "^2.0.0",
     "locate-path": "^7.2.0",
     "lodash-es": "^4.17.21",
@@ -76,6 +75,7 @@
     "mem-fs-editor": "^11.1.4",
     "semver": "^7.7.2",
     "slash": "^5.1.0",
+    "tinyglobby": "^0.2.14",
     "untildify": "^5.0.0",
     "which-package-manager": "^1.0.1"
   },

--- a/src/module-lookup.ts
+++ b/src/module-lookup.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import process from 'node:process';
 import arrify from 'arrify';
 import { compact, uniq } from 'lodash-es';
-import { type Options as GlobbyOptions, globbySync } from 'globby';
+import { type GlobOptions as GlobbyOptions, globSync } from 'tinyglobby';
 import slash from 'slash';
 import createdLogger from 'debug';
 import { execaOutput } from './util/util.js';
@@ -76,7 +76,7 @@ export function moduleLookupSync(
       continue;
     }
 
-    const files = globbySync(options.filePatterns, {
+    const files = globSync(options.filePatterns, {
       cwd: packagePath,
       absolute: true,
       ...options.globbyOptions,
@@ -122,7 +122,7 @@ export function findPackagesIn(searchPaths: string[], packagePatterns: string[],
     // restricted folders.
     try {
       modules = modules.concat(
-        globbySync(packagePatterns, {
+        globSync(packagePatterns, {
           cwd: root,
           onlyDirectories: true,
           expandDirectories: false,
@@ -135,7 +135,7 @@ export function findPackagesIn(searchPaths: string[], packagePatterns: string[],
       // To limit recursive lookups into non-namespace folders within globby,
       // fetch all namespaces in root, then search each namespace separately
       // for generator modules
-      const scopes = globbySync(['@*'], {
+      const scopes = globSync(['@*'], {
         cwd: root,
         onlyDirectories: true,
         expandDirectories: false,
@@ -146,7 +146,7 @@ export function findPackagesIn(searchPaths: string[], packagePatterns: string[],
 
       for (const scope of scopes) {
         modules = modules.concat(
-          globbySync(packagePatterns, {
+          globSync(packagePatterns, {
             cwd: scope,
             onlyDirectories: true,
             expandDirectories: false,


### PR DESCRIPTION
<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/.github/blob/master/.github/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [x] Enhancement
- [ ] Other, please explain:

## What changes did you make?

Switched from `globby` to `tinyglobby`

I'm not sure why `npm ci` is failing. Maybe this project uses an old version of `npm`? It works fine for me locally

## Is there anything you'd like reviewers to focus on?

https://npmgraph.js.org/?q=tinyglobby - 2 dependencies
https://npmgraph.js.org/?q=globby - 23 dependencies