### PR TITLE
fix: use globbySync to resolve PNPM global node_modules paths

### DIFF
--- a/src/module-lookup.ts
+++ b/src/module-lookup.ts
@@ -278,7 +278,7 @@ function getGlobalNpmPaths(filterPaths = true): string[] {
         onlyDirectories: true,
         suppressErrors: true,
         absolute: true,
-      }).map(modulesPath => resolve(pnpmHome, modulesPath)),
+      }).map(modulesPath => resolve(modulesPath)),
     );
   }
 


### PR DESCRIPTION
Fixes #693 

<!--
Allo' allo'! 
Thanks for taking the time to submit a pull request ❤

Please make sure you read and fulfill our pull request guidelines:
https://github.com/yeoman/.github/blob/master/.github/contributing.md

Additional useful information is placed on the Yeoman Website:
http://yeoman.io/contributing/pull-request.html
-->

## Purpose of this pull request? 

- [ ] Documentation update
- [X] Bug fix 
- [ ] Enhancement
- [ ] Other, please explain:

## What changes did you make?

<!-- Give an overview -->
Switched to using globbySync when pushing all pnpm node_module directories to paths array. The ```global/*/node_modules``` path was failing this existsSync check as the directory doesn't actually exist and so none of the pnpm installed generators could be found
```js
if (!existsSync(root) || (!lstatSync(root).isDirectory() && !lstatSync(root).isSymbolicLink())) {
      continue;
```

<!-- Just in case -->